### PR TITLE
Fix: Correct Hilt Navigation Compose dependency reference

### DIFF
--- a/romtools/build.gradle.kts
+++ b/romtools/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
 
     // Hilt for dependency injection
     implementation(libs.hilt.android)
-    implementation(libs.hilt.navigation.compose)  // For hiltViewModel()
+    implementation(libs.androidx.hilt.navigation.compose)  // For hiltViewModel()
     ksp(libs.hilt.compiler)
 
     // Kotlin coroutines


### PR DESCRIPTION
Changed from:
  libs.hilt.navigation.compose

To:
  libs.androidx.hilt.navigation.compose

The version catalog defines this dependency with the "androidx-" prefix (androidx-hilt-navigation-compose), so the reference must include it.

## Summary by Sourcery

Bug Fixes:
- Correct the Hilt Navigation Compose dependency reference to use the androidx-prefixed catalog entry