### PR TITLE
Fix: Set Java compileOptions to VERSION_24 across all Android modules

### DIFF
--- a/build-logic/src/main/kotlin/plugins/GenesisBasePlugin.kt
+++ b/build-logic/src/main/kotlin/plugins/GenesisBasePlugin.kt
@@ -1,5 +1,7 @@
 package plugins
 
+import com.android.build.api.dsl.CommonExtension
+import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -17,6 +19,24 @@ class GenesisBasePlugin : Plugin<Project> {
         plugins.withId("org.jetbrains.kotlin.jvm") {
             extensions.configure(KotlinJvmProjectExtension::class.java) {
                 compilerOptions.jvmTarget.set(JvmTarget.fromTarget("24"))
+            }
+        }
+
+        // Configure Android compileOptions for library and application modules
+        plugins.withId("com.android.library") {
+            extensions.configure(CommonExtension::class.java) {
+                compileOptions {
+                    sourceCompatibility = JavaVersion.VERSION_24
+                    targetCompatibility = JavaVersion.VERSION_24
+                }
+            }
+        }
+        plugins.withId("com.android.application") {
+            extensions.configure(CommonExtension::class.java) {
+                compileOptions {
+                    sourceCompatibility = JavaVersion.VERSION_24
+                    targetCompatibility = JavaVersion.VERSION_24
+                }
             }
         }
     }

--- a/collab-canvas/build.gradle.kts
+++ b/collab-canvas/build.gradle.kts
@@ -15,6 +15,11 @@ android {
             compose = true
         }
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_24
+        targetCompatibility = JavaVersion.VERSION_24
+    }
 }
 dependencies {
     // Include local JARs for Xposed API

--- a/core-module/build.gradle.kts
+++ b/core-module/build.gradle.kts
@@ -16,6 +16,12 @@ android {
             compose = true
         }
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_24
+        targetCompatibility = JavaVersion.VERSION_24
+    }
+
     dependencies {
         api(libs.androidx.core.ktx) // if APIs leak types
         implementation(libs.androidx.appcompat)

--- a/romtools/build.gradle.kts
+++ b/romtools/build.gradle.kts
@@ -10,6 +10,11 @@ plugins {
 android {
     namespace = "dev.aurakai.auraframefx.romtools"
     compileSdk = 36
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_24
+        targetCompatibility = JavaVersion.VERSION_24
+    }
 }
 dependencies {
     // Include local JARs for Xposed API (paths must be relative to this module)

--- a/secure-comm/build.gradle.kts
+++ b/secure-comm/build.gradle.kts
@@ -10,6 +10,11 @@ plugins {
 android {
     namespace = "dev.aurakai.auraframefx.securecomm"
     compileSdk = 36
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_24
+        targetCompatibility = JavaVersion.VERSION_24
+    }
 }
 dependencies {
     // Include local JARs for Xposed API


### PR DESCRIPTION
Problem:
Android Gradle Plugin was using default Java version (11 or 17) while Kotlin was targeting JVM 24, causing bytecode version mismatch errors.

Solution:
1. Updated GenesisBasePlugin convention to configure compileOptions:
   - Added JavaVersion.VERSION_24 for sourceCompatibility
   - Added JavaVersion.VERSION_24 for targetCompatibility
   - Applies to both com.android.library and com.android.application

2. Added explicit compileOptions to individual modules:
   - romtools/build.gradle.kts
   - collab-canvas/build.gradle.kts
   - secure-comm/build.gradle.kts
   - core-module/build.gradle.kts

This ensures Java and Kotlin compile targets are aligned:
- Java: sourceCompatibility = VERSION_24, targetCompatibility = VERSION_24
- Kotlin: jvmTarget = "24"
- Java Toolchain: languageVersion = 24/25

Resolves: "JVM target compatibility warning (Java 11 vs Kotlin 24)"

## Summary by Sourcery

Align Java and Kotlin compilation targets to Java Version 24 across all Android modules to resolve bytecode version mismatch errors.

Bug Fixes:
- Fix JVM bytecode compatibility errors by setting Java compileOptions to VERSION_24 to match Kotlin jvmTarget=24.

Enhancements:
- Update GenesisBasePlugin to configure sourceCompatibility and targetCompatibility to JavaVersion.VERSION_24 for both Android library and application plugins.
- Add explicit compileOptions with JavaVersion.VERSION_24 to core-module, collab-canvas, romtools, and secure-comm build scripts.