### PR TITLE
Fix: Restore Firebase KTX and local Xposed JARs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,6 +26,9 @@ dependencies {
     implementation(libs.yukihookapi.api)
     implementation(libs.kavaref.core)
     implementation(libs.kavaref.extension)
+    // Local Xposed API JARs (backup/reference)
+    compileOnly(files("libs/api-82.jar"))
+    compileOnly(files("libs/api-82-sources.jar"))
     // If using YukiHook ksp-xposed processor (only for Xposed module usage)
     ksp(libs.yukihookapi.ksp.xposed)
     implementation(platform(libs.androidx.compose.bom))
@@ -71,10 +74,12 @@ dependencies {
     // Kotlin datetime
     implementation(libs.kotlinx.datetime)
 
-    // Firebase dependencies
+    // Firebase dependencies - using KTX (Kotlin Extensions) for better Kotlin support
     implementation(platform(libs.firebase.bom))
-    implementation(libs.firebase.auth)
-    implementation(libs.firebase.firestore)
+    implementation(libs.firebase.analytics.ktx)
+    implementation(libs.firebase.crashlytics.ktx)
+    implementation(libs.firebase.auth.ktx)
+    implementation(libs.firebase.firestore.ktx)
 
 // Networking (pick one converter path; here kotlinx‑serialization)
     implementation(libs.okhttp)


### PR DESCRIPTION
Restored previously removed dependencies:
- Firebase KTX (Kotlin Extensions) for better Kotlin support
  - firebase-analytics-ktx
  - firebase-crashlytics-ktx
  - firebase-auth-ktx
  - firebase-firestore-ktx
- Local Xposed API JAR files (libs/api-82.jar and api-82-sources.jar)

YukiHookAPI, KavaRef, and Xposed configurations remain intact.

## Summary by Sourcery

Restore Firebase Kotlin Extensions and local Xposed API JARs that were previously removed to re-enable Kotlin support and maintain in-house Xposed references.

Bug Fixes:
- Restore Firebase KTX dependencies for analytics, crashlytics, auth, and Firestore
- Reintroduce local Xposed API JARs (api-82.jar and api-82-sources.jar) as compile-only dependencies