### PR TITLE
Fix: Replace JitPack YukiHookAPI with Maven Central version

### DIFF
--- a/collab-canvas/build.gradle.kts
+++ b/collab-canvas/build.gradle.kts
@@ -22,7 +22,7 @@ android {
 }
 dependencies {
     compileOnly(files("$projectDir/libs/api-82.jar"))
-    ksp("com.github.LSPosed.YukiHookAPI:yuApiClient:1.3.1")
+    ksp("com.highcapable.yukihookapi:ksp-xposed:1.3.1")
 
     // Libsu for root operations
     implementation(libs.libsu.core)

--- a/colorblendr/build.gradle.kts
+++ b/colorblendr/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     implementation(libs.compose.ui)
     implementation(libs.compose.material3)
     compileOnly(files("$projectDir/libs/api-82.jar"))
-    ksp("com.github.LSPosed.YukiHookAPI:yuApiClient:1.3.1")
+    ksp("com.highcapable.yukihookapi:ksp-xposed:1.3.1")
 
 // Hilt in library
     implementation(libs.hilt.android)

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.timber)
     compileOnly(files("$projectDir/libs/api-82.jar"))
-    ksp("com.github.LSPosed.YukiHookAPI:yuApiClient:1.3.1")
+    ksp("com.highcapable.yukihookapi:ksp-xposed:1.3.1")
 
 // If this library uses Compose UI:
     implementation(platform(libs.androidx.compose.bom))

--- a/datavein-oracle-native/build.gradle.kts
+++ b/datavein-oracle-native/build.gradle.kts
@@ -17,7 +17,7 @@ android {
     dependencies {
         // Include local libs directory for compileOnly dependencies
         compileOnly(files("$projectDir/libs/api-82.jar"))
-        ksp("com.github.LSPosed.YukiHookAPI:yuApiClient:1.3.1")
+        ksp("com.highcapable.yukihookapi:ksp-xposed:1.3.1")
 
 
         // Libsu for root operations

--- a/feature-module/build.gradle.kts
+++ b/feature-module/build.gradle.kts
@@ -12,7 +12,7 @@ android {
 dependencies {
     // Include local libs directory for compileOnly dependencies
     compileOnly(files("$projectDir/libs/api-82.jar"))
-    ksp("com.github.LSPosed.YukiHookAPI:yuApiClient:1.3.1")
+    ksp("com.highcapable.yukihookapi:ksp-xposed:1.3.1")
 
 
     // Libsu for root operations

--- a/oracle-drive-integration/build.gradle.kts
+++ b/oracle-drive-integration/build.gradle.kts
@@ -12,7 +12,7 @@ android {
 dependencies {
     // Include local libs directory for compileOnly dependencies (module-local)
     compileOnly(files("$projectDir/libs/api-82.jar"))
-    ksp("com.github.LSPosed.YukiHookAPI:yuApiClient:1.3.1")
+    ksp("com.highcapable.yukihookapi:ksp-xposed:1.3.1")
 
 
     // Libsu for root operations

--- a/romtools/build.gradle.kts
+++ b/romtools/build.gradle.kts
@@ -17,7 +17,7 @@ android {
 }
 dependencies {
     compileOnly(files("$projectDir/libs/api-82.jar"))
-    ksp("com.github.LSPosed.YukiHookAPI:yuApiClient:1.3.1")
+    ksp("com.highcapable.yukihookapi:ksp-xposed:1.3.1")
 
 
     // Libsu for root operations

--- a/secure-comm/build.gradle.kts
+++ b/secure-comm/build.gradle.kts
@@ -17,7 +17,7 @@ android {
 }
 dependencies {
     compileOnly(files("$projectDir/libs/api-82.jar"))
-    ksp("com.github.LSPosed.YukiHookAPI:yuApiClient:1.3.1")
+    ksp("com.highcapable.yukihookapi:ksp-xposed:1.3.1")
 
     implementation(libs.libsu.core)
     implementation(libs.libsu.io)


### PR DESCRIPTION
Fixed build failure across 8 modules caused by JitPack 401 Unauthorized error.

Problem:
- Modules were using: com.github.LSPosed.YukiHookAPI:yuApiClient:1.3.1 (JitPack)
- JitPack was returning 401 Unauthorized

Solution:
- Switched to: com.highcapable.yukihookapi:ksp-xposed:1.3.1 (Maven Central)
- This is the official Maven Central release of YukiHookAPI

Affected modules (8):
- core:ui
- collab-canvas
- datavein-oracle-native
- feature-module
- oracle-drive-integration
- colorblendr
- romtools
- secure-comm

Build should now succeed.

## Summary by Sourcery

Bug Fixes:
- Switch YukiHookAPI from com.github.LSPosed.YukiHookAPI:yuApiClient:1.3.1 (JitPack) to com.highcapable.yukihookapi:ksp-xposed:1.3.1 (Maven Central) across eight modules