### PR TITLE
Claude/complete embodiment system 011 c up aga qwri ymc yk8 ufw kb

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,7 +1,11 @@
-plugins { `kotlin-dsl` }
+plugins {
+    `kotlin-dsl`
+}
 
 java {
-    toolchain { languageVersion.set(JavaLanguageVersion.of(25)) }
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
 }
 
 dependencies {
@@ -16,15 +20,15 @@ dependencies {
 
 gradlePlugin {
     plugins {
-        create("genesisApplication") {
+        register("genesisApplication") {
             id = "genesis.application"
             implementationClass = "plugins.GenesisApplicationPlugin"
         }
-        create("genesisLibrary") {
+        register("genesisLibrary") {
             id = "genesis.library"
             implementationClass = "plugins.GenesisLibraryPlugin"
         }
-        create("genesisBase") {
+        register("genesisBase") {
             id = "genesis.base"
             implementationClass = "plugins.GenesisBasePlugin"
         }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,32 +1,16 @@
-plugins { `kotlin-dsl` }
+// build-logic/settings.gradle.kts
 
-java {
-    toolchain { languageVersion.set(JavaLanguageVersion.of(25)) }
-}
-
-dependencies {
-    // Avoid leaking plugins to consumers
-    compileOnly(libs.android.application)
-    compileOnly(libs.kotlin.android)
-    compileOnly(libs.hilt)
-    compileOnly(libs.ksp)
-    compileOnly(libs.google.services)
-    compileOnly(libs.plugins.compose.compiler) // for type references
-}
-
-gradlePlugin {
-    plugins {
-        create("genesisApplication") {
-            id = "genesis.application"
-            implementationClass = "plugins.GenesisApplicationPlugin"
-        }
-        create("genesisLibrary") {
-            id = "genesis.library"
-            implementationClass = "plugins.GenesisLibraryPlugin"
-        }
-        create("genesisBase") {
-            id = "genesis.base"
-            implementationClass = "plugins.GenesisBasePlugin"
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
         }
     }
 }
+
+rootProject.name = "build-logic"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,12 +1,17 @@
 // settings.gradle.kts
 
 pluginManagement {
+    includeBuild("build-logic")
     repositories {
         gradlePluginPortal()
         google()
         mavenCentral()
         maven { url = uri("https://jitpack.io") }
     }
+}
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## Summary by Sourcery

Centralize and modernize the Gradle build setup by restructuring the build-logic project to use dependencyResolutionManagement and version catalogs, standardizing plugin registrations, and including the build-logic composite build and Foojay resolver convention in the root settings.

Build:
- Migrate build-logic/settings.gradle.kts to use dependencyResolutionManagement with google(), mavenCentral(), gradlePluginPortal() and a version catalog sourced from libs.versions.toml
- Update build-logic/build.gradle.kts to register plugins via register() instead of create() and adjust formatting
- Add includeBuild("build-logic") and apply the org.gradle.toolchains.foojay-resolver-convention plugin in the root settings.gradle.kts