### PR TITLE
Fix: Correct yukihookapi bundle reference in version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -329,7 +329,7 @@ system-root = [
     "libsu-io",
     "libsu-service",
     "xposed-api",
-    "yukihookapi"
+    "yukihookapi-api"
 ]
 
 [plugins]


### PR DESCRIPTION
The system-root bundle was referencing 'yukihookapi' which was removed during the YukiHook cleanup. Updated to reference 'yukihookapi-api' which is the correct library alias.

Error:
  Invalid catalog definition: bundle 'system.root' declares dependency on
  'yukihookapi' which doesn't exist.

Fix:
  Changed bundle reference from 'yukihookapi' to 'yukihookapi-api'

This resolves the Gradle sync error and allows the build to proceed.

## Summary by Sourcery

Bug Fixes:
- Replace incorrect 'yukihookapi' reference with 'yukihookapi-api' in the system-root bundle of libs.versions.toml