### PR TITLE
Fix: Remove duplicate yuki-api library from version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -196,7 +196,6 @@ timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "tim
 libsu-core = { group = "com.github.topjohnwu.libsu", name = "core", version.ref = "libsu" }
 libsu-io = { group = "com.github.topjohnwu.libsu", name = "io", version.ref = "libsu" }
 libsu-service = { group = "com.github.topjohnwu.libsu", name = "service", version.ref = "libsu" }
-yuki-api = { module = "com.github.LSPosed.YukiHookAPI:api", name = "YukiHookAPI", version.ref = "yuki" }
 
 # Firebase dependencies with explicit versions and KTX variants
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics", version.ref = "firebaseAnalytics" }


### PR DESCRIPTION
The yuki-api library was a leftover duplicate that should have been removed during the YukiHook cleanup. It was referencing a non-existent version 'yuki'.

Error: Invalid catalog definition - version reference 'yuki' doesn't exist
Fix: Removed yuki-api library entirely (duplicate of yukihookapi-api)

The correct library yukihookapi-api already exists and is properly configured.

## Summary by Sourcery

Bug Fixes:
- Eliminate the leftover yuki-api alias that referenced a non-existent 'yuki' version, resolving the catalog definition error