### PR TITLE
fix: Resolve Kotlin gradle plugin dependency by adding dev repository…

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,9 +22,9 @@ hilt = "2.57.2"
 # Note: Docs showed 1.2.0 stable, but 1.3.0 exists and is in use
 hiltWork = "1.3.0"
 
-# Kotlin - Using beta for K2 compiler improvements and new features
-# Stable: 2.2.21, Beta: 2.3.0-Beta3
-kotlin = "2.3.0-Beta3"
+# Kotlin - Latest stable: 2.2.21, Latest beta: 2.3.0-Beta2
+# Note: KSP versioning (2.3.x) is now independent of Kotlin version
+kotlin = "2.3.0-Beta2"
 
 # Kotlin DSL
 kotlinDsl = "5.1.2"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,8 @@ pluginManagement {
         gradlePluginPortal()
         google()
         mavenCentral()
+        // Kotlin dev repository for beta/EAP releases
+        maven { url = uri("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev") }
         maven { url = uri("https://jitpack.io") }
     }
 }


### PR DESCRIPTION
… and using correct beta version

The error "Could not resolve org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.0-Beta3" occurred because:
1. Kotlin beta versions require the JetBrains dev repository
2. Version 2.3.0-Beta3 does not exist yet (latest beta is 2.3.0-Beta2)

Changes:
- Added Kotlin dev repository (https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev) to pluginManagement
- Updated Kotlin version from "2.3.0-Beta3" to "2.3.0-Beta2" (verified latest beta)
- Clarified that KSP versioning (2.3.x) is now independent of Kotlin version per KSP 2.3.0 release notes

This resolves the dependency resolution error while keeping you on the latest available Kotlin beta.

## Summary by Sourcery

Add Kotlin dev repository and correct beta version to fix Kotlin Gradle plugin resolution

Bug Fixes:
- Resolve kotlin-gradle-plugin resolution error by adding JetBrains dev Maven repository

Enhancements:
- Revert Kotlin version to the latest available beta (2.3.0-Beta2)

Build:
- Include Kotlin dev repository in pluginManagement block

Documentation:
- Note in comments that KSP 2.3.x versioning is independent of the Kotlin version