### PR TITLE
fix: Add google-services-plugin to version catalog

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -12,13 +12,12 @@ java {
 
 dependencies {
     // Plugin dependencies for convention plugins
-    // These allow the convention plugins to apply Android, Kotlin, Hilt, KSP, and Firebase plugins
     // These allow the convention plugins to apply Android, Kotlin, Hilt, KSP, and Google Services plugins
-    compileOnly(libs.gradle.plugin)
-    compileOnly(libs.kotlin.gradle.plugin)
-    compileOnly(libs.hilt.gradle.plugin)
-    compileOnly(libs.ksp.gradle.plugin)
-    compileOnly(libs.google.services.plugin)
+    implementation(libs.gradle.plugin)
+    implementation(libs.kotlin.gradle.plugin)
+    implementation(libs.hilt.gradle.plugin)
+    implementation(libs.ksp.gradle.plugin)
+    implementation(libs.google.services.gradle.plugin)
 }
 // ═══════════════════════════════════════════════════════════════════════════
 // Binary Kotlin Class Plugins Registration
@@ -55,9 +54,7 @@ gradlePlugin {
         }
     }
 }
-    // Plugin dependencies for convention plugins
-    // These allow the convention plugins to apply Android, Kotlin, Hilt, KSP, and Firebase plugins
-//
+
 // ═══════════════════════════════════════════════════════════════════════════
 // CORRECT USAGE EXAMPLES
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Added the missing google-services-plugin library entry to libs.versions.toml that was referenced in build-logic/build.gradle.kts but not defined.

This fixes the compilation error:
  "Function invocation 'plugin(...)' expected"
  at build.gradle.kts:19

The plugin is required for convention plugins to apply Google Services (Firebase).

## Summary by Sourcery

Fix the compilation error by adding the missing Google Services plugin to the version catalog and updating build-logic dependencies to implementation

Bug Fixes:
- Add missing google-services plugin entry to libs.versions.toml
- Change convention plugin dependencies in build-logic from compileOnly to implementation to resolve plugin invocation error