### PR TITLE
fix: Add version to foojay-resolver-convention plugin in settings.gra…

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,7 +13,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention")
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
 
 


### PR DESCRIPTION
…dle.kts

The foojay-resolver-convention plugin requires an explicit version when used in settings.gradle.kts. Added version "0.8.0" to resolve the error:
  "Plugin [id: 'org.gradle.toolchains.foojay-resolver-convention'] was not found"

This plugin helps automatically download JDKs for Gradle toolchains.

## Summary by Sourcery

Bug Fixes:
- Specify version "0.8.0" for the org.gradle.toolchains.foojay-resolver-convention plugin to resolve "Plugin was not found" error