### PR TITLE
Claude/fix kotlin gradle plugin 011 c ur3io rmpv fq aex st xcu1

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -13,10 +13,11 @@ java {
 dependencies {
     // Plugin dependencies for convention plugins
     // These allow the convention plugins to apply Android, Kotlin, Hilt, KSP, and Google Services plugins
-    compileOnly(libs.gradle.plugin)
-    compileOnly(libs.kotlin.gradle.plugin)
-    compileOnly(libs.hilt.gradle.plugin)
-    compileOnly(libs.ksp.gradle.plugin)
+    implementation(libs.gradle.plugin)
+    implementation(libs.kotlin.gradle.plugin)
+    implementation(libs.hilt.gradle.plugin)
+    implementation(libs.ksp.gradle.plugin)
+    implementation(libs.google.services.gradle.plugin)
 }
 // ═══════════════════════════════════════════════════════════════════════════
 // Binary Kotlin Class Plugins Registration

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -76,8 +76,6 @@ include(":romtools")
 // Add your other feature modules here...
 include(":oracle-drive-integration")
 include(":datavein-oracle-native")
-include(":feature-module")
-project(":feature-module").projectDir = File(rootDir, "featuremodule")
 // --- Core Modules ---
 include(":core:domain")
 include(":core:data")


### PR DESCRIPTION
## Summary by Sourcery

Update build-logic to use implementation for Gradle, Kotlin, Hilt, and KSP plugins, add the Google services plugin, and remove obsolete feature-module from project settings.

New Features:
- Add Google services Gradle plugin to build-logic dependencies

Bug Fixes:
- Remove deprecated feature-module include and projectDir configuration from settings.gradle.kts

Enhancements:
- Change convention plugin dependencies from compileOnly to implementation in build-logic/build.gradle.kts