### PR TITLE
fix(build-logic): Fix corrupted gradle file and plugin configuration

### DIFF
--- a/build-logic/src/main/kotlin/genesis.android.application.gradle.kts
+++ b/build-logic/src/main/kotlin/genesis.android.application.gradle.kts
@@ -17,8 +17,8 @@ plugins {
     // 4. Apply KSP for code generation (used by Hilt, Room, Moshi)
     id("com.google.devtools.ksp")
 
-    // 5. Apply the Kotlin Serialization plugin using kotlin() DSL
-    kotlin("plugin.serialization")
+    // 5. Apply the Kotlin Serialization plugin
+    id("org.jetbrains.kotlin.plugin.serialization")
 
     // 6. Apply Compose Compiler plugin
     id("org.jetbrains.kotlin.plugin.compose")
@@ -61,28 +61,13 @@ android {
         buildConfig = true
     }
 
-    // Configure the Compose compiler
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
-    }
+    // Note: composeOptions {} is DEPRECATED with Kotlin 2.0+
+    // Compose compiler is now built-in via org.jetbrains.kotlin.plugin.compose
 }
 
 // Add dependencies that every application module needs
 dependencies {
-    dependencies {
-        // Plugin dependencies for convention plugins
-        // These allow the convention plugins to apply Android, Kotlin, Hilt, KSP, and Firebase plugins
-        implementation(libs.gradle.plugin)
-        -    implementation(libs.kotlin.gradle.plugin)
-        -    implementation(libs.hilt.gradle.plugin)
-        -    implementation(libs.ksp.gradle.plugin)
-        -    implementation(libs.google.services.plugin)
-        +    compileOnly(libs.gradle.plugin)
-        +    compileOnly(libs.kotlin.gradle.plugin)
-        +    compileOnly(libs.hilt.gradle.plugin)
-        +    compileOnly(libs.ksp.gradle.plugin)
-        +    compileOnly(libs.google.services.plugin)
-            // Hilt
+    // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 


### PR DESCRIPTION
Fixed critical issues in genesis.android.application.gradle.kts:

1. **Plugin Configuration**
   - Changed kotlin("plugin.serialization") to full ID format
   - Precompiled script plugins require full plugin IDs
   - Now uses: id("org.jetbrains.kotlin.plugin.serialization")

2. **Removed Deprecated Configuration**
   - Removed composeOptions block (deprecated with Kotlin 2.0+)
   - Compose compiler now built-in via org.jetbrains.kotlin.plugin.compose
   - Added comment explaining the change

3. **Fixed Corrupted Dependencies Block**
   - Removed merge conflict markers and duplicate dependencies block
   - Cleaned up malformed diff markers (-/+ lines)
   - Restored proper dependencies structure

This resolves the build failure:
"Plugin [id: 'org.jetbrains.kotlin.plugin.serialization'] was not found"

The Kotlin gradle plugin is already in build-logic dependencies, but the plugin ID shorthand doesn't work in precompiled scripts.

## Summary by Sourcery

Fix the Android build-logic script by correcting plugin configuration, removing deprecated settings, and cleaning up a corrupted dependencies block.

Bug Fixes:
- Correct the Kotlin serialization plugin apply syntax to use the full plugin ID and resolve the missing plugin error
- Remove merge conflict markers and duplicate entries to restore a valid dependencies block

Enhancements:
- Replace kotlin("plugin.serialization") with id("org.jetbrains.kotlin.plugin.serialization") for precompiled scripts
- Remove the deprecated composeOptions block and note that the Compose compiler is now built-in via the compose plugin