### PR TITLE
Refactor: Clean up deprecated Gradle properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,9 +24,7 @@ kotlin.code.style=official
 kotlin.incremental=true
 # Build optimization
 android.optimize.build=true
-nonewdsl=true
 android.enableDesugaring=true
-android.builtInKotlin=false
 # Compose Configuration
 androidx.compose.compiler.plugin.enableKotlinDebugLogging=true
 androidx.compose.compiler.plugin.enableDebugProguardRules=false
@@ -41,7 +39,7 @@ org.gradle.java.installations.auto-download=true
 org.gradle.jvmargs=-Xmx10g
 # Dokka V2 migration
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
-org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
+org.jetbrains.dokka.experimental.pluginMode.noWarn=true
 # AGP 9.0+ specific properties
 org.gradle.java.installations.auto-detect=true
 # Kotlin bytecode target guard


### PR DESCRIPTION
Removes deprecated and obsolete properties from `gradle.properties` to align with modern Gradle and Android Gradle Plugin standards.

Key changes:
- Removed `nonewdsl=true` as it is no longer required.
- Removed `android.builtInKotlin=false` as it is obsolete.
- Corrected the Dokka property from `org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn` to `org.jetbrains.dokka.experimental.pluginMode.noWarn`.

## Summary by Sourcery

Clean up obsolete Gradle properties and correct Dokka plugin property key in gradle.properties

Build:
- Remove deprecated nonewdsl and android.builtInKotlin properties
- Correct Dokka property key from experimental.gradle.pluginMode.noWarn to experimental.pluginMode.noWarn