### PR TITLE
fix(oracledrive): Remove hardcoded Kotlin version and migrate to conv…

### DIFF
--- a/oracledrive/core/common/build.gradle.kts
+++ b/oracledrive/core/common/build.gradle.kts
@@ -1,85 +1,87 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Oracle Drive - Core Common Layer (Shared Utilities)
+// ═══════════════════════════════════════════════════════════════════════════
 plugins {
-    id("com.android.library") version "9.0.0-alpha13" // This likely applies the base configurations already
-    id("org.jetbrains.kotlin.plugin.compose") version "2.2.21"
-    id("com.google.devtools.ksp") version "2.3.0"
-    id("com.google.dagger.hilt.android") version "2.57.2"
-    alias(libs.plugins.serialization)
+    id("genesis.android.library")
 }
+
 android {
     namespace = "dev.aurakai.auraframefx.core.common"
-    compileSdk = 36
-
-
 }
 
 dependencies {
-    // Utilities and extensions
+    // Core Android
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.activity.compose)
-    implementation(libs.androidx.security.crypto)
 
-    // --- Jetpack Compose (versions are managed by the BOM from the convention plugin) ---
+    // Compose
     implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.material3) // Standardize on Material 3 for Compose
-    implementation(libs.androidx.navigation.compose)
-    debugImplementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.compose.ui)
+    implementation(libs.compose.ui.tooling.preview)
+    implementation(libs.compose.material3)
+    debugImplementation(libs.compose.ui.tooling)
 
-    // --- Lifecycle ---
+    // Navigation
+    implementation(libs.androidx.navigation.compose)
+
+    // Lifecycle
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
 
-    // --- Hilt (plugin applied by `genesis.android.library`) ---
+    // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
-    implementation(libs.androidx.hilt.navigation.compose) // Ensure this alias points to the compose version
+    implementation(libs.androidx.hilt.navigation.compose)
 
-    // --- Room (KSP is applied by convention plugin) ---
+    // Room
     ksp(libs.androidx.room.compiler)
 
-    // --- DataStore ---
+    // DataStore
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.datastore.core)
 
-    // --- Coroutines & Serialization ---
+    // Kotlin
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.datetime)
 
-    // --- Networking ---
-    implementation(libs.retrofit) // Assuming you have clearer aliases
+    // Networking
+    implementation(libs.retrofit)
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging.interceptor)
-    // Standardize on one converter. kotlinx.serialization is the modern default.
     implementation(libs.retrofit.converter.kotlinx.serialization)
 
-    // --- Firebase ---
+    // Firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth)
 
-    // --- Background Work ---
+    // WorkManager
     implementation(libs.androidx.work.runtime.ktx)
 
-    // --- Utilities (Logging, Root) ---
-    implementation(libs.timber)
+    // Security
+    implementation(libs.androidx.security.crypto)
+
+    // Root/System
     implementation(libs.libsu.core)
     implementation(libs.libsu.io)
 
-    // --- Hooking Frameworks (Compile Only) ---
+    // Logging
+    implementation(libs.timber)
+
+    // Xposed/YukiHook (compile-only)
     compileOnly(libs.xposed.api)
-    compileOnly(libs.yukihookapi)
+    compileOnly(libs.yukihookapi.api)
 
-
-    // --- Desugaring (Enabled by convention plugin) ---
+    // Desugaring
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 
-    // --- Testing ---
-    testImplementation(libs.junit.jupiter.api)
+    // Testing
+    testImplementation(libs.junit.jupiter)
     androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.hilt.android.testing)
-    androidTestImplementation(libs.androidx.benchmark.junit4)
-    androidTestImplementation(libs.androidx.test.uiautomator)
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.espresso.core)
+    androidTestImplementation(libs.benchmark.junit4)
 }

--- a/oracledrive/core/data/build.gradle.kts
+++ b/oracledrive/core/data/build.gradle.kts
@@ -1,42 +1,40 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Oracle Drive - Core Data Layer
+// ═══════════════════════════════════════════════════════════════════════════
 plugins {
-    id("com.android.library") version "9.0.0-alpha13" // This likely applies the base configurations already
-    id("org.jetbrains.kotlin.plugin.compose") version "2.2.21"
-    id("com.google.devtools.ksp") version "2.3.0"
-    id("com.google.dagger.hilt.android") version "2.57.2"
-    alias(libs.plugins.serialization)
+    id("genesis.android.library")
 }
-
 
 android {
     namespace = "dev.aurakai.auraframefx.core.data"
-    compileSdk = 36
-
 }
 
 dependencies {
     // Expose domain layer
-    api(project(":core:domain"))
-    compileOnly(libs.xposed.api)
-    compileOnly(libs.yukihookapi)
-    implementation(libs.androidx.core.ktx)
+    api(project(":oracledrive:core:domain"))
+
+    // Common utilities
+    implementation(project(":oracledrive:core:common"))
 
     // Data layer dependencies
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.datastore.core)
 
-    // Hilt - required when alias(libs.plugins.hilt) is applied
+    // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 
-    // Common utilities
-    implementation(project(":core:common"))
+    // Root/System Operations
+    implementation(libs.libsu.core)
+    implementation(libs.libsu.io)
+    implementation(libs.libsu.service)
 
-    // Testing
+    // Networking
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.logging.interceptor)
+    implementation(libs.retrofit.converter.kotlinx.serialization)
 
-    implementation("com.github.topjohnwu.libsu:core:6.0.0")
-    implementation("com.github.topjohnwu.libsu:io:6.0.0")
-    implementation("com.github.topjohnwu.libsu:service:6.0.0")
-    compileOnly("de.robv.android.xposed:api:82")
-    implementation("com.squareup.retrofit2:converter-kotlinx-serialization:1.0.0")
-    implementation("com.squareup.okhttp3:logging-interceptor:${libs.versions.okhttp.get()}")
+    // Xposed/YukiHook (compile-only)
+    compileOnly(libs.xposed.api)
+    compileOnly(libs.yukihookapi.api)
 }

--- a/oracledrive/core/domain/build.gradle.kts
+++ b/oracledrive/core/domain/build.gradle.kts
@@ -1,91 +1,90 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Oracle Drive - Core Domain Layer (Business Logic)
+// ═══════════════════════════════════════════════════════════════════════════
 plugins {
-    id("com.android.library") version "9.0.0-alpha13" // This likely applies the base configurations already
-    id("org.jetbrains.kotlin.plugin.compose") version "2.2.21"
-    id("com.google.devtools.ksp") version "2.3.0"
-    id("com.google.dagger.hilt.android") version "2.57.2"
-    alias(libs.plugins.serialization)
+    id("genesis.android.library")
 }
 
 android {
     namespace = "dev.aurakai.auraframefx.core.domain"
-    compileSdk = 36
-
 }
 
-
 dependencies {
-    // Pure business logic, no Android dependencies
-    implementation(libs.kotlinx.coroutines.core)
-    implementation(project(":core:common"))
-    // Testing
+    // Common utilities
+    implementation(project(":oracledrive:core:common"))
 
-    // Utilities and extensions
+    // Core Android
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.activity.compose)
-    implementation(libs.androidx.security.crypto)
 
-    // --- Jetpack Compose (versions are managed by the BOM from the convention plugin) ---
+    // Compose
     implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.material3) // Standardize on Material 3 for Compose
-    implementation(libs.androidx.navigation.compose)
-    debugImplementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.compose.ui)
+    implementation(libs.compose.ui.tooling.preview)
+    implementation(libs.compose.material3)
+    debugImplementation(libs.compose.ui.tooling)
 
-    // --- Lifecycle ---
+    // Navigation
+    implementation(libs.androidx.navigation.compose)
+
+    // Lifecycle
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
 
-    // --- Hilt (plugin applied by `genesis.android.library`) ---
+    // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
-    implementation(libs.androidx.hilt.navigation.compose) // Ensure this alias points to the compose version
+    implementation(libs.androidx.hilt.navigation.compose)
 
-    // --- Room (KSP is applied by convention plugin) ---
+    // Room
     ksp(libs.androidx.room.compiler)
 
-    // --- DataStore ---
+    // DataStore
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.datastore.core)
 
-    // --- Coroutines & Serialization ---
+    // Kotlin
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.datetime)
 
-    // --- Networking ---
-    implementation(libs.retrofit) // Assuming you have clearer aliases
+    // Networking
+    implementation(libs.retrofit)
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging.interceptor)
-    // Standardize on one converter. kotlinx.serialization is the modern default.
     implementation(libs.retrofit.converter.kotlinx.serialization)
 
-    // --- Firebase ---
+    // Firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth)
 
-    // --- Background Work ---
+    // WorkManager
     implementation(libs.androidx.work.runtime.ktx)
 
-    // --- Utilities (Logging, Root) ---
-    implementation(libs.timber)
+    // Security
+    implementation(libs.androidx.security.crypto)
+
+    // Root/System
     implementation(libs.libsu.core)
     implementation(libs.libsu.io)
 
-    // --- Hooking Frameworks (Compile Only) ---
+    // Logging
+    implementation(libs.timber)
+
+    // Xposed/YukiHook (compile-only)
     compileOnly(libs.xposed.api)
-    compileOnly(libs.yukihookapi)
+    compileOnly(libs.yukihookapi.api)
 
-
-    // --- Desugaring (Enabled by convention plugin) ---
+    // Desugaring
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 
-    // --- Testing ---
-    testImplementation(libs.junit.jupiter.api)
+    // Testing
+    testImplementation(libs.junit.jupiter)
     androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.hilt.android.testing)
-    androidTestImplementation(libs.androidx.benchmark.junit4)
-    androidTestImplementation(libs.androidx.test.uiautomator)
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.espresso.core)
+    androidTestImplementation(libs.benchmark.junit4)
 }

--- a/oracledrive/core/ui/build.gradle.kts
+++ b/oracledrive/core/ui/build.gradle.kts
@@ -1,74 +1,92 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Oracle Drive - Core UI Layer
+// ═══════════════════════════════════════════════════════════════════════════
 plugins {
-    id("com.android.library") version "9.0.0-alpha13" // This likely applies the base configurations already
-    id("org.jetbrains.kotlin.plugin.compose") version "2.2.21"
-    id("com.google.devtools.ksp") version "2.3.0"
-    id("com.google.dagger.hilt.android") version "2.57.2"
-    alias(libs.plugins.serialization)
+    id("genesis.android.library")
 }
 
 android {
     namespace = "dev.aurakai.auraframefx.core.ui"
-    compileSdk = 36
-
 }
+
 dependencies {
+    // Common utilities
+    implementation(project(":oracledrive:core:common"))
+
+    // Core Android
+    implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
-    implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.material)
-    implementation(libs.androidx.core.ktx)
+
+    // Lifecycle
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+
+    // Compose
     implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.material)
-    implementation(libs.material3)
+    implementation(libs.compose.ui)
+    implementation(libs.compose.ui.tooling.preview)
+    implementation(libs.compose.material3)
+    debugImplementation(libs.compose.ui.tooling)
+
+    // Navigation
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation.compose)
-    debugImplementation(libs.androidx.compose.ui.tooling)
 
+    // Hilt
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+    implementation(libs.androidx.hilt.navigation.compose)
+
+    // Room
     ksp(libs.androidx.room.compiler)
 
+    // DataStore
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.datastore.core)
 
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
-
+    // Kotlin
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.datetime)
-    implementation(libs.coroutines)
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.android)
+
+    // Networking
     implementation(libs.retrofit)
     implementation(libs.okhttp)
-    implementation("com.squareup.retrofit2:converter-moshi:3.0.0")
-    implementation("com.squareup.retrofit2:converter-kotlinx-serialization:1.0.0")
-    implementation("com.squareup.okhttp3:logging-interceptor:${libs.versions.okhttp.get()}")
-    implementation(libs.androidx.work.runtime.ktx)
-    implementation(libs.androidx.security.crypto)
-    implementation(libs.androidx.hilt.navigation)
+    implementation(libs.okhttp.logging.interceptor)
+    implementation(libs.retrofit.converter.moshi)
+    implementation(libs.retrofit.converter.kotlinx.serialization)
 
+    // WorkManager
+    implementation(libs.androidx.work.runtime.ktx)
+
+    // Security
+    implementation(libs.androidx.security.crypto)
+
+    // Firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth)
 
+    // Root/System
     implementation(libs.libsu.core)
     implementation(libs.libsu.io)
 
+    // Logging
     implementation(libs.timber)
 
+    // Xposed/YukiHook (compile-only)
     compileOnly(libs.xposed.api)
-    compileOnly(libs.yukihookapi)
+    compileOnly(libs.yukihookapi.api)
 
+    // Desugaring
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 
-    testImplementation(libs.junit.jupiter.api)
-    androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.hilt.android.testing)
-    androidTestImplementation(libs.androidx.benchmark.junit4)
-    androidTestImplementation(libs.androidx.test.uiautomator)
-
-    implementation(project(":core:common"))
-
     // Testing
+    testImplementation(libs.junit.jupiter)
     androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.espresso.core)
+    androidTestImplementation(libs.benchmark.junit4)
 }

--- a/oracledrive/datavein-oracle-native/build.gradle.kts
+++ b/oracledrive/datavein-oracle-native/build.gradle.kts
@@ -1,81 +1,89 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Oracle Drive - DataVein Oracle Native
+// ═══════════════════════════════════════════════════════════════════════════
 plugins {
-    id("com.android.library") version "9.0.0-alpha13" // This likely applies the base configurations already
-    id("org.jetbrains.kotlin.plugin.compose") version "2.2.21"
-    id("com.google.devtools.ksp") version "2.3.0"
-    id("com.google.dagger.hilt.android") version "2.57.2"
-    alias(libs.plugins.serialization)
+    id("genesis.android.library")
 }
 
 android {
     namespace = "dev.aurakai.auraframefx.dataveinoraclenative"
-    compileSdk = 36
-
 }
 
 dependencies {
-    // Root/hooking dependencies (grouped together at the top)
-    implementation(libs.androidx.appcompat) // added to ensure appcompat is present
-    // Use local jars in project `libs/` folder to resolve Xposed API offline
-    implementation(libs.libsu.core)
-    implementation("com.github.topjohnwu.libsu:core:5.0.4")
-    implementation("com.github.topjohnwu.libsu:io:5.0.4")
-    implementation(libs.libsu.io)
-
-    // Hooking/runtime-only compile-time APIs for modules that interact with Xposed/YukiHook
-    compileOnly(libs.yukihookapi)
-    compileOnly(libs.xposed.api)
+    // Core Android
+    implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
-    implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.material)
-    implementation(libs.androidx.core.ktx)
+
+    // Lifecycle
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+
+    // Compose
     implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.material)
-    implementation(libs.material3)
+    implementation(libs.compose.ui)
+    implementation(libs.compose.ui.tooling.preview)
+    implementation(libs.compose.material3)
+    debugImplementation(libs.compose.ui.tooling)
+
+    // Navigation
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation.compose)
-    debugImplementation(libs.androidx.compose.ui.tooling)
 
+    // Hilt
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+    implementation(libs.androidx.hilt.navigation.compose)
+
+    // Room
     ksp(libs.androidx.room.compiler)
 
+    // DataStore
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.datastore.core)
 
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
-
+    // Kotlin
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.datetime)
-    implementation(libs.coroutines)
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.android)
+
+    // Networking
     implementation(libs.retrofit)
     implementation(libs.okhttp)
-    implementation("com.squareup.retrofit2:converter-moshi:3.0.0")
-    implementation("com.squareup.retrofit2:converter-kotlinx-serialization:1.0.0")
-    implementation("com.squareup.okhttp3:logging-interceptor:${libs.versions.okhttp.get()}")
-    implementation(libs.androidx.work.runtime.ktx)
-    implementation(libs.androidx.security.crypto)
-    implementation(libs.androidx.hilt.navigation)
+    implementation(libs.okhttp.logging.interceptor)
+    implementation(libs.retrofit.converter.moshi)
+    implementation(libs.retrofit.converter.kotlinx.serialization)
 
+    // WorkManager
+    implementation(libs.androidx.work.runtime.ktx)
+
+    // Security
+    implementation(libs.androidx.security.crypto)
+
+    // Firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth)
 
+    // Root/System Operations
     implementation(libs.libsu.core)
     implementation(libs.libsu.io)
 
+    // Logging
     implementation(libs.timber)
 
+    // Xposed/YukiHook (compile-only)
     compileOnly(libs.xposed.api)
-    compileOnly(libs.yukihookapi)
+    compileOnly(libs.yukihookapi.api)
 
+    // Desugaring
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 
-    testImplementation(libs.junit.jupiter.api)
+    // Testing
+    testImplementation(libs.junit.jupiter)
     androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.hilt.android.testing)
-    androidTestImplementation(libs.androidx.benchmark.junit4)
-    androidTestImplementation(libs.androidx.test.uiautomator)
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.espresso.core)
+    androidTestImplementation(libs.benchmark.junit4)
 }

--- a/oracledrive/integration/oracle-drive-integration/build.gradle.kts
+++ b/oracledrive/integration/oracle-drive-integration/build.gradle.kts
@@ -6,72 +6,94 @@
 // Status: Awaiting implementation (0 source files)
 // Documented: Yes (see README.md)
 // Remove this module if not implementing soon to reduce build time.
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Oracle Drive - Integration Module
+// ═══════════════════════════════════════════════════════════════════════════
 plugins {
-    id("com.android.library")
-    id("com.google.devtools.ksp")
-    id("com.google.dagger.hilt.android")
-    id("org.jetbrains.kotlin.plugin.serialization")
+    id("genesis.android.library")
 }
 
 android {
     namespace = "dev.aurakai.auraframefx.oracledriveintegration"
-    compileSdk = 36
-
 }
+
 dependencies {
+    // Core Android
+    implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
-    implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.material)
-    implementation(libs.androidx.core.ktx)
+
+    // Lifecycle
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+
+    // Compose
     implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.compose.ui)
-    implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.material)
-    implementation(libs.material3)
+    implementation(libs.compose.ui)
+    implementation(libs.compose.ui.tooling.preview)
+    implementation(libs.compose.material3)
+    debugImplementation(libs.compose.ui.tooling)
+
+    // Navigation
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation.compose)
-    debugImplementation(libs.androidx.compose.ui.tooling)
-    compileOnly(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
+    // Hilt
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+    implementation(libs.androidx.hilt.navigation.compose)
+
+    // Room
     ksp(libs.androidx.room.compiler)
 
+    // DataStore
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.datastore.core)
 
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
-
+    // Kotlin
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.datetime)
-    implementation(libs.coroutines)
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.android)
+
+    // Networking
     implementation(libs.retrofit)
     implementation(libs.okhttp)
-    implementation("com.squareup.retrofit2:converter-moshi:3.0.0")
-    implementation("com.squareup.retrofit2:converter-kotlinx-serialization:1.0.0")
-    implementation("com.squareup.okhttp3:logging-interceptor:${libs.versions.okhttp.get()}")
-    implementation(libs.androidx.work.runtime.ktx)
-    implementation(libs.androidx.security.crypto)
-    implementation(libs.androidx.hilt.navigation)
+    implementation(libs.okhttp.logging.interceptor)
+    implementation(libs.retrofit.converter.moshi)
+    implementation(libs.retrofit.converter.kotlinx.serialization)
 
+    // WorkManager
+    implementation(libs.androidx.work.runtime.ktx)
+
+    // Security
+    implementation(libs.androidx.security.crypto)
+
+    // Firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth)
 
+    // Root/System Operations
     implementation(libs.libsu.core)
     implementation(libs.libsu.io)
 
+    // Logging
     implementation(libs.timber)
 
+    // Xposed/YukiHook (compile-only)
     compileOnly(libs.xposed.api)
-    compileOnly(libs.yukihookapi)
+    compileOnly(libs.yukihookapi.api)
+    compileOnly(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
+    // Desugaring
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 
-    testImplementation(libs.junit.jupiter.api)
+    // Testing
+    testImplementation(libs.junit.jupiter)
     androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.hilt.android.testing)
-    androidTestImplementation(libs.androidx.benchmark.junit4)
-    androidTestImplementation(libs.androidx.test.uiautomator)
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.espresso.core)
+    androidTestImplementation(libs.benchmark.junit4)
 }


### PR DESCRIPTION
…ention plugins

Addresses AI reviewer feedback from PR #74 regarding version conflicts.

**Problem:**
- 5 oracledrive modules had hardcoded Kotlin plugin version "2.2.21"
- Project uses Kotlin 2.3.0-Beta2 in version catalog
- Caused version conflicts and inconsistent build configuration
- Modules manually declared all plugins with explicit versions

**Solution:**
Migrated all oracledrive modules to use `genesis.android.library` convention plugin:

**Modules Fixed:**
1. `oracledrive/core/data` - Data layer
2. `oracledrive/core/ui` - UI layer
3. `oracledrive/core/domain` - Business logic
4. `oracledrive/core/common` - Shared utilities
5. `oracledrive/datavein-oracle-native` - Native integration
6. `oracledrive/integration/oracle-drive-integration` - Placeholder module

**Changes:**
- Removed hardcoded plugin versions:
  - `id("com.android.library") version "9.0.0-alpha13"`
  - `id("org.jetbrains.kotlin.plugin.compose") version "2.2.21"` ❌
  - `id("com.google.devtools.ksp") version "2.3.0"`
  - `id("com.google.dagger.hilt.android") version "2.57.2"`

- Replaced with convention plugin:
  - `id("genesis.android.library")` ✅

- Cleaned up dependencies:
  - Removed duplicate declarations
  - Standardized on version catalog references
  - Removed hardcoded version strings
  - Fixed outdated libsu version (5.0.4 → 6.0.0)

**Benefits:**
- All modules now use consistent Kotlin 2.3.0-Beta2
- Single source of truth for plugin versions
- Easier maintenance and updates
- Eliminates version conflicts
- Follows project's convention plugin architecture

**Related:**
- Resolves AI reviewer concerns from PR #74
- Consistent with build-logic fix in bfb361d
- Part of Phase 1 Dependabot updates (d329bc8)