### PR TITLE
fix: Remove Java 8 from GenesisLibraryPlugin - use Java 24

### DIFF
--- a/build-logic/src/main/kotlin/GenesisLibraryPlugin.kt
+++ b/build-logic/src/main/kotlin/GenesisLibraryPlugin.kt
@@ -33,13 +33,13 @@ class GenesisLibraryPlugin : Plugin<Project> {
                 }
 
                 compileOptions {
-                    sourceCompatibility = JavaVersion.VERSION_1_8
-                    targetCompatibility = JavaVersion.VERSION_1_8
+                    sourceCompatibility = JavaVersion.VERSION_24
+                    targetCompatibility = JavaVersion.VERSION_24
                 }
 
                 // Correct way to set Kotlin JVM target inside android extension
                 (this as org.gradle.api.plugins.ExtensionAware).extensions.configure<org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions>("kotlinOptions") {
-                    jvmTarget = "1.8"
+                    jvmTarget = "24"
                 }
 
                 buildFeatures {


### PR DESCRIPTION
CRITICAL FIX: GenesisLibraryPlugin was hardcoded to Java 1.8, causing build failure.

Changes:
- sourceCompatibility: VERSION_1_8 -> VERSION_24
- targetCompatibility: VERSION_1_8 -> VERSION_24
- kotlinOptions jvmTarget: "1.8" -> "24"

This aligns with the project-wide Java 25/24 configuration and fixes: "Cannot find a Java installation matching: {languageVersion=8}"

File modified:
- build-logic/src/main/kotlin/GenesisLibraryPlugin.kt

## Summary by Sourcery

Use Java 24 in GenesisLibraryPlugin instead of Java 8

Bug Fixes:
- Bump compileOptions source and target compatibility to Java 24
- Upgrade Kotlin JVM target to 24