### PR TITLE
Merge remote-tracking branch 'origin/claude/fix-gradle-build-errors-011CUjZexLenoBohaZmwvjW6' into claude/fix-gradle-build-errors-011CUjZexLenoBohaZmwvjW6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,7 @@
 # ===== AGP 9.0 + HILT + KSP COMPATIBILITY =====
 # Required for AGP 9.x + KSP + Hilt stability
-android.builtInKotlin=false
 android.newDsl=false
-
+org.gradle.java.installations.auto-detect=false
 # AndroidX and Compose
 android.useAndroidX=true
 android.nonFinalResIds=true
@@ -15,30 +14,27 @@ org.gradle.daemon=true
 org.gradle.configureondemand=true
 # KSP Configuration (aligned with Kotlin 2.3.0-Beta2)
 ksp.incremental=true
-ksp.kotlinApiVersion=2.3
-ksp.kotlinLanguageVersion=2.3
+ksp.kotlinApiVersion=2.4
+ksp.kotlinLanguageVersion=2.4
 # Kotlin Configuration
 kotlin.code.style=official
 kotlin.incremental=true
 # Build optimization
 android.optimize.build=true
-nonewdsl=true
+nonewdsl=false
 android.enableDesugaring=true
 android.builtInKotlin=false
 # Compose Configuration
 android.compose.experimentalStrongSkippingEnabled=true
 # Configuration cache (use standard mode, TURBO is experimental)
-org.gradle.configuration-cache=true
+org.gradle.configuration-cache=false
 org.gradle.configuration-cache.problems=warn
 # Build reproducibility
 org.gradle.caching.reproducible=true
-org.gradle.java.installations.auto-download=true
-org.gradle.jvmargs=-Xmx10g
 # Dokka V2 migration
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 # AGP 9.0+ specific properties
-org.gradle.java.installations.auto-detect=true
 
 # JVM Memory (10GB for large project)
 org.gradle.jvmargs=-Xmx10g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC


### PR DESCRIPTION
## Summary by Sourcery

Fix Gradle build errors by updating Kotlin Symbol Processing versions, disabling conflicting Gradle features, and cleaning up JVM and JDK configuration in gradle.properties

Bug Fixes:
- Update KSP kotlinApiVersion and kotlinLanguageVersion to 2.4 to match Kotlin version
- Disable new DSL and Gradle configuration cache to ensure compatibility with AGP 9.0
- Turn off automatic JDK detection and auto-download to prevent conflicting installations
- Consolidate JVM arguments with increased heap size, heap dump on OOM, and parallel GC

Enhancements:
- Remove duplicate android.builtInKotlin setting

Chores:
- Reorganize and tidy gradle.properties flags for AGP, KSP, Compose, and overall build optimization