### PR TITLE
Fix: AGP 9.0 + Hilt Compatibility - Genesis Protocol Solution

### DIFF
--- a/build-logic/src/main/kotlin/GenesisApplicationPlugin.kt
+++ b/build-logic/src/main/kotlin/GenesisApplicationPlugin.kt
@@ -56,8 +56,9 @@ class GenesisApplicationPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         with(project) {
             // Apply plugins in correct order
-            // Note: kotlin-android plugin removed - AGP 9.0 has built-in Kotlin support
+            // Note: Using EXTERNAL kotlin-android plugin (android.builtInKotlin=false for Hilt compatibility)
             pluginManager.apply("com.android.application")
+            pluginManager.apply("org.jetbrains.kotlin.android")
             pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
             pluginManager.apply("com.google.dagger.hilt.android")
             pluginManager.apply("com.google.devtools.ksp")

--- a/build-logic/src/main/kotlin/GenesisLibraryPlugin.kt
+++ b/build-logic/src/main/kotlin/GenesisLibraryPlugin.kt
@@ -37,8 +37,9 @@ class GenesisLibraryPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         with(project) {
             // Apply plugins in correct order
-            // Note: kotlin-android plugin removed - AGP 9.0 has built-in Kotlin support
+            // Note: Using EXTERNAL kotlin-android plugin (android.builtInKotlin=false for Hilt compatibility)
             pluginManager.apply("com.android.library")
+            pluginManager.apply("org.jetbrains.kotlin.android")
             pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
             pluginManager.apply("com.google.dagger.hilt.android")
             pluginManager.apply("com.google.devtools.ksp")

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,9 +21,15 @@ kotlin.code.style=official
 kotlin.incremental=true
 # Build optimization
 android.optimize.build=true
-android.newDsl=true
 android.enableDesugaring=true
-android.builtInKotlin=true
+
+# ===== CRITICAL: AGP 9.0 + Hilt Compatibility (Genesis Protocol Solution) =====
+# Documented in: context/docs/AGP9_HILT_COMPATIBILITY_GUIDE.md
+# The key breakthrough: Force external Kotlin plugin instead of AGP 9.0's built-in
+android.builtInKotlin=false
+kotlin.builtInKotlin=false
+org.gradle.kotlin.dsl.builtin=false
+android.disableLastStageWhenHiltIsApplied=true
 # Compose Configuration
 android.compose.experimentalStrongSkippingEnabled=true
 # Configuration cache (use standard mode, TURBO is experimental)


### PR DESCRIPTION
Applied the documented Genesis Protocol breakthrough for AGP 9.0 + Hilt:

gradle.properties:
- android.builtInKotlin=false (force external Kotlin plugin)
- kotlin.builtInKotlin=false
- org.gradle.kotlin.dsl.builtin=false
- android.disableLastStageWhenHiltIsApplied=true

Convention Plugins:
- Re-added org.jetbrains.kotlin.android plugin (required for external Kotlin)
- GenesisApplicationPlugin applies kotlin-android
- GenesisLibraryPlugin applies kotlin-android

This approach provides proper Kotlin compiler environment for Hilt's annotation processing pipeline, avoiding "BaseExtension not found" errors.

Documented in: context/docs/AGP9_HILT_COMPATIBILITY_GUIDE.md
Reference: docs/guides/ALIGNMENT_COMPLETE_AGP_9.0.0-ALPHA14.md

## Summary by Sourcery

Fix AGP 9.0 compatibility issues with Hilt by forcing the external Kotlin plugin and adjusting convention plugins accordingly.

Bug Fixes:
- Disable AGP’s built-in Kotlin and force the external Kotlin plugin in gradle.properties to resolve Hilt annotation processing errors
- Re-add the kotlin-android plugin in GenesisApplicationPlugin and GenesisLibraryPlugin to ensure a proper Kotlin compiler environment for Hilt

Documentation:
- Add AGP9_HILT_COMPATIBILITY_GUIDE.md to document the breakthrough solution for AGP 9.0 + Hilt compatibility