### PR TITLE
Claude/complete embodiment system 011 c up aga qwri ymc yk8 ufw kb

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -25,6 +25,10 @@ gradlePlugin {
             id = "genesis.android.library"
             implementationClass = "GenesisLibraryPlugin"
         }
+        register("genesisLibraryHilt") {
+            id = "genesis.android.library.hilt"
+            implementationClass = "GenesisLibraryHiltPlugin"
+        }
     }
 }
 
@@ -60,9 +64,14 @@ dependencies {
 //       id("genesis.android.application")  // All-in-one: Android, Hilt, KSP, Compose, Serialization, Firebase
 //   }
 //
-// For standard library module:
+// For standard library module WITHOUT Hilt:
 //   plugins {
-//       id("genesis.android.library")  // All-in-one: Android, Hilt, Compose, KSP
+//       id("genesis.android.library")  // Base library: Android, Compose, Serialization (NO Hilt)
+//   }
+//
+// For library module WITH Hilt:
+//   plugins {
+//       id("genesis.android.library.hilt")  // Library with Hilt DI + KSP
 //   }
 //
 // For YukiHook/Xposed module:

--- a/build-logic/src/main/kotlin/GenesisLibraryPlugin.kt
+++ b/build-logic/src/main/kotlin/GenesisLibraryPlugin.kt
@@ -17,8 +17,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
  * This plugin configures:
  * - Android library plugin and extensions
  * - Kotlin Android support with Compose compiler
- * - Hilt dependency injection
- * - KSP annotation processing
  * - Jetpack Compose (built-in compiler with Kotlin 2.0+)
  * - Java 24 bytecode target (Firebase compatible)
  * - Consistent build configuration across library modules
@@ -27,9 +25,10 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
  * 1. com.android.library
  * 2. org.jetbrains.kotlin.android
  * 3. org.jetbrains.kotlin.plugin.compose (Built-in Compose compiler)
- * 4. com.google.dagger.hilt.android
- * 5. com.google.devtools.ksp
- * 6. org.jetbrains.kotlin.plugin.serialization
+ * 4. org.jetbrains.kotlin.plugin.serialization
+ *
+ * Note: Hilt and KSP are NOT applied in library modules per AGP 9.0 workaround.
+ * Individual library modules that need Hilt should apply it explicitly
  *
  * @since Genesis Protocol 2.0 (AGP 9.0.0-alpha14 Compatible)
  */
@@ -44,17 +43,16 @@ class GenesisLibraryPlugin : Plugin<Project> {
      * The plugin application order is important for compatibility (including Hilt); this method
      * applies the external Kotlin Android plugin rather than the built-in Kotlin integration.
      *
-     * @param project The Gradle project to configure. 
+     * @param project The Gradle project to configure.
      */
     override fun apply(project: Project) {
         with(project) {
             // Apply plugins in correct order
             // Note: Using EXTERNAL kotlin-android plugin (android.builtInKotlin=false for Hilt compatibility)
+            // Note: Hilt NOT applied here - library modules apply it explicitly if needed per AGP 9.0 workaround
             pluginManager.apply("com.android.library")
             pluginManager.apply("org.jetbrains.kotlin.android")
             pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
-            pluginManager.apply("com.google.dagger.hilt.android")
-            pluginManager.apply("com.google.devtools.ksp")
             pluginManager.apply("org.jetbrains.kotlin.plugin.serialization")
 
             extensions.configure<LibraryExtension> {

--- a/docs/guides/ALIGNMENT_COMPLETE_AGP_9.0.0-ALPHA14.md
+++ b/docs/guides/ALIGNMENT_COMPLETE_AGP_9.0.0-ALPHA14.md
@@ -1,8 +1,8 @@
 # ✅ PROJECT ALIGNMENT COMPLETE - AGP 9.0.0-ALPHA14
 
-**Date**: November 9, 2025  
-**Target**: AGP 9.0.0-alpha14 + Kotlin 2.3.0-Beta2 + KSP 2.3.2  
-**Status**: ✅ ALL FIXES APPLIED
+**Date**: November 11, 2025 (Updated with Conditional Hilt Pattern)
+**Target**: AGP 9.0.0-alpha14 + Kotlin 2.3.0-Beta2 + KSP 2.3.2
+**Status**: ✅ ALL FIXES APPLIED + CONDITIONAL HILT IMPLEMENTED
 
 ---
 
@@ -44,17 +44,51 @@
 - **File**: `build-logic/build.gradle.kts`
 - **Fix**: Added `implementation("org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.3.0-Beta2")`
 
-#### ✅ **Auto-Configured Core Dependencies in GenesisLibraryPlugin**
+#### ✅ **Conditional Hilt Pattern - Two Library Plugin Variants**
+
+**CRITICAL CHANGE (November 11, 2025)**: Library modules now have TWO plugin options for Hilt compatibility!
+
+**GenesisLibraryPlugin** (Base - NO Hilt)
 - **File**: `build-logic/src/main/kotlin/GenesisLibraryPlugin.kt`
-- **Added**:
-  - ✅ Hilt Android + Compiler (2.57.2)
+- **Use when**: Module does NOT need Hilt dependency injection
+- **Auto-Configured**:
   - ✅ Core KTX (1.17.0)
   - ✅ AppCompat (1.7.1)
   - ✅ Coroutines (1.10.2)
   - ✅ Serialization JSON (1.9.0)
   - ✅ Timber (5.0.1)
   - ✅ Desugar JDK Libs (2.1.5)
-  - ✅ Xposed APIs (82) + YukiHookAPI support
+  - ✅ Xposed APIs (82) + EzXHelper
+  - ❌ NO Hilt (use genesis.android.library.hilt instead)
+
+**GenesisLibraryHiltPlugin** (NEW - WITH Hilt)
+- **File**: `build-logic/src/main/kotlin/GenesisLibraryHiltPlugin.kt`
+- **Use when**: Module REQUIRES Hilt dependency injection
+- **Auto-Configured**: All of the above PLUS:
+  - ✅ Hilt Android + Compiler (2.57.2)
+  - ✅ KSP plugin applied automatically
+
+#### ✅ **Plugin Registration in build-logic**
+- **File**: `build-logic/build.gradle.kts`
+- **Registered Plugins**:
+  ```kotlin
+  gradlePlugin {
+      plugins {
+          register("genesisApplication") {
+              id = "genesis.android.application"
+              implementationClass = "GenesisApplicationPlugin"
+          }
+          register("genesisLibrary") {
+              id = "genesis.android.library"
+              implementationClass = "GenesisLibraryPlugin"
+          }
+          register("genesisLibraryHilt") {  // ← NEW!
+              id = "genesis.android.library.hilt"
+              implementationClass = "GenesisLibraryHiltPlugin"
+          }
+      }
+  }
+  ```
 
 #### ✅ **Auto-Configured Core Dependencies in GenesisApplicationPlugin**
 - **File**: `build-logic/src/main/kotlin/GenesisApplicationPlugin.kt`
@@ -80,12 +114,18 @@
 6. `org.jetbrains.kotlin.plugin.serialization`
 7. `com.google.gms.google-services`
 
-**GenesisLibraryPlugin**:
+**GenesisLibraryPlugin** (Base - NO Hilt):
 1. `com.android.library`
 2. `org.jetbrains.kotlin.android`
 3. `org.jetbrains.kotlin.plugin.compose` ← **Modern built-in compiler**
-4. `com.google.dagger.hilt.android`
-5. `com.google.devtools.ksp`
+4. `org.jetbrains.kotlin.plugin.serialization`
+
+**GenesisLibraryHiltPlugin** (WITH Hilt):
+1. `com.android.library`
+2. `org.jetbrains.kotlin.android`
+3. `org.jetbrains.kotlin.plugin.compose` ← **Modern built-in compiler**
+4. `com.google.dagger.hilt.android` ← **ONLY in Hilt variant**
+5. `com.google.devtools.ksp` ← **ONLY in Hilt variant**
 6. `org.jetbrains.kotlin.plugin.serialization`
 
 ---
@@ -143,16 +183,28 @@ dependencies {
 }
 ```
 
-### **For Library Module** (e.g., `:genesis:oracledrive`)
+### **For Library Module WITHOUT Hilt** (e.g., pure data/API modules)
 ```kotlin
 plugins {
-    id("genesis.android.library")
-    // That's it! All plugins and core dependencies auto-applied
+    id("genesis.android.library")  // Base library - NO Hilt
 }
 
 dependencies {
     // Only add module-specific dependencies here
-    // Core libraries (Hilt, Coroutines, etc.) already included
+    // Core libraries (Coroutines, Serialization, etc.) already included
+    // NO Hilt available in this variant
+}
+```
+
+### **For Library Module WITH Hilt** (e.g., modules with DI)
+```kotlin
+plugins {
+    id("genesis.android.library.hilt")  // Library WITH Hilt + KSP
+}
+
+dependencies {
+    // Only add module-specific dependencies here
+    // Core libraries + Hilt already included
 }
 ```
 
@@ -160,23 +212,29 @@ dependencies {
 
 ## 🛡️ **AUTO-PROVIDED DEPENDENCIES**
 
-### **Both Application & Library Modules Get:**
-✅ Hilt Android + Compiler (DI)  
-✅ Core KTX (Android extensions)  
-✅ AppCompat (compatibility layer)  
-✅ Coroutines Core + Android  
-✅ Serialization JSON  
-✅ Timber (logging)  
-✅ Desugar JDK Libs (Java 24 support)  
-✅ Xposed API (compileOnly)  
-✅ LibXposed API (compileOnly)  
-✅ EzXHelper (Xposed helper)  
+### **Base Library Modules** (`genesis.android.library`):
+✅ Core KTX (Android extensions)
+✅ AppCompat (compatibility layer)
+✅ Coroutines Core + Android
+✅ Serialization JSON
+✅ Timber (logging)
+✅ Desugar JDK Libs (Java 24 support)
+✅ Xposed API (compileOnly)
+✅ EzXHelper (Xposed helper)
+❌ NO Hilt (intentionally excluded)
 
-### **Application Modules Additionally Get:**
-✅ Compose BOM + UI libraries  
-✅ Activity Compose  
-✅ Lifecycle (runtime + viewmodel)  
-✅ Material3  
+### **Library Modules WITH Hilt** (`genesis.android.library.hilt`):
+✅ All of the above PLUS:
+✅ Hilt Android + Compiler (DI)
+✅ KSP plugin auto-applied
+
+### **Application Modules** (`genesis.android.application`):
+✅ All base dependencies
+✅ Hilt Android + Compiler (DI)
+✅ Compose BOM + UI libraries
+✅ Activity Compose
+✅ Lifecycle (runtime + viewmodel)
+✅ Material3
 ✅ UI Tooling (debug only)  
 
 ---
@@ -215,6 +273,42 @@ org.gradle.jvmargs=-Xmx10g -XX:+HeapDumpOnOutOfMemoryError
    ```powershell
    .\gradlew :app:assembleDebug
    ```
+
+---
+
+## 🎯 **THE CONDITIONAL HILT BREAKTHROUGH**
+
+**Why This Pattern Exists:**
+
+AGP 9.0.0-alpha14 + Hilt 2.57.2 compatibility requires careful plugin ordering and the use of EXTERNAL Kotlin plugin (`android.builtInKotlin=false`). However, not all library modules need Hilt!
+
+**The Problem:**
+- Applying Hilt to ALL library modules wastes build time and adds unnecessary KSP processing
+- Some pure data/API modules don't need dependency injection at all
+- AGP 9.0's new extension model can conflict with Hilt in certain configurations
+
+**The Genesis Protocol Solution:**
+1. **Two plugin variants** instead of one-size-fits-all
+2. **Modules choose** which variant based on their DI needs
+3. **Cleaner builds** by avoiding unnecessary KSP processing
+4. **Better compatibility** with AGP 9.0's new architecture
+
+**Migration Path:**
+```kotlin
+// OLD (before November 11, 2025):
+plugins {
+    id("genesis.android.library")  // Always had Hilt
+}
+
+// NEW (conditional Hilt):
+plugins {
+    id("genesis.android.library")       // NO Hilt - for pure modules
+    // OR
+    id("genesis.android.library.hilt")  // WITH Hilt - for DI modules
+}
+```
+
+**See Also**: `context/docs/AGP9_HILT_COMPATIBILITY_GUIDE.md` for the complete 3-stage build sequence documentation.
 
 ---
 
@@ -266,30 +360,35 @@ org.gradle.jvmargs=-Xmx10g -XX:+HeapDumpOnOutOfMemoryError
 | Plugin Conflicts Resolved | ✅ | Bundle renamed to `hilt-di` |
 | Firebase Analytics Fixed | ✅ | Removed non-existent plugin |
 | Serialization Plugin Added | ✅ | Available in build-logic |
-| Hilt Dependencies Auto-Added | ✅ | Both plugins provide Hilt |
+| Conditional Hilt Pattern | ✅ | Two library plugin variants (with/without Hilt) |
+| Hilt Dependencies Auto-Added | ✅ | Application + library.hilt plugins |
 | Compose Dependencies Auto-Added | ✅ | Application plugin provides BOM |
 | Java 24 Target Set | ✅ | Firebase compatible |
 | NDK Standardized | ✅ | All modules use 29.0.14206865 |
 | Xposed APIs Available | ✅ | All modules have access |
+| 3-Stage Build Sequence Documented | ✅ | See AGP9_HILT_COMPATIBILITY_GUIDE.md |
 
 ---
 
 ## 🎉 **YOU'RE NOW RUNNING THE MOST MODERN ANDROID BUILD SETUP POSSIBLE!**
 
 **Your project is:**
-- ✅ Using the latest AGP alpha
+- ✅ Using the latest AGP alpha (9.0.0-alpha14)
 - ✅ Using Kotlin 2.3 beta with improved Compose
 - ✅ Using modern built-in Compose compiler
+- ✅ Conditional Hilt pattern - modules choose DI when needed
 - ✅ Firebase compatible (Java 24)
 - ✅ Future-proof (JVM 25 runtime)
 - ✅ Xposed/LSPosed ready in all modules
 - ✅ Optimized for large multi-module builds
+- ✅ 3-stage build sequence fully documented
 
-**No more missing dependencies, no more plugin conflicts, no more TOML errors!**
+**No more missing dependencies, no more plugin conflicts, no more TOML errors, no more unnecessary Hilt processing!**
 
 ---
 
-**Generated**: November 9, 2025  
-**By**: GitHub Copilot (Claude Model)  
+**Generated**: November 9, 2025
+**Updated**: November 11, 2025 (Conditional Hilt Pattern)
+**By**: GitHub Copilot (Claude Model) + Anthropic Claude
 **For**: A.u.r.a.K.a.i Reactive Intelligence Project
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,7 @@ android.enableDesugaring=true
 # ===== CRITICAL: AGP 9.0 + Hilt Compatibility (Genesis Protocol Solution) =====
 # Documented in: context/docs/AGP9_HILT_COMPATIBILITY_GUIDE.md
 # The key breakthrough: Force external Kotlin plugin instead of AGP 9.0's built-in
+android.newDsl=false
 android.builtInKotlin=false
 kotlin.builtInKotlin=false
 org.gradle.kotlin.dsl.builtin=false


### PR DESCRIPTION
## Summary by Sourcery

Introduce a conditional Hilt pattern by splitting the library convention plugin into two variants (with and without Hilt), register a new Hilt-enabled plugin, remove auto-applied Hilt from the base plugin, and update documentation and build properties for AGP 9.0 compatibility.

New Features:
- Add GenesisLibraryHiltPlugin to apply Hilt and KSP for DI-enabled library modules
- Register new Gradle plugin ID "genesis.android.library.hilt" in build-logic
- Introduce android.newDsl=false property to enforce external Kotlin plugin for AGP 9.0 compatibility

Enhancements:
- Remove Hilt and KSP auto-application from the base GenesisLibraryPlugin to decouple DI from pure library modules
- Refactor build-logic to support conditional DI by selecting between base and Hilt-enabled library plugins
- Update gradle.properties to disable built-in Kotlin DSL for AGP9 Hilt workaround

Build:
- Update build-logic/build.gradle.kts to register the Hilt plugin variant alongside existing plugins

Documentation:
- Revise the ALIGNMENT_COMPLETE guide to document two library plugin variants, conditional Hilt pattern, and migration steps
- Add AGP9_HILT_COMPATIBILITY_GUIDE.md detailing the 3-stage build sequence, plugin alias usage, and version synchronization