### PR TITLE
Fix: Downgrade all Genesis convention plugins from Java 24 to Java 21

### DIFF
--- a/build-logic/src/main/kotlin/GenesisApplicationPlugin.kt
+++ b/build-logic/src/main/kotlin/GenesisApplicationPlugin.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
  * - KSP annotation processing
  * - Jetpack Compose (built-in compiler with Kotlin 2.0+)
  * - Google Services (Firebase)
- * - Java 25 runtime with Java 24 bytecode target (Firebase compatible)
+ * - Java 21 bytecode target
  * - Consistent build configuration across app modules
  *
  * Plugin Application Order (Critical!):
@@ -91,10 +91,10 @@ class GenesisApplicationPlugin : Plugin<Project> {
                     }
                 }
 
-                // Java 24 bytecode (Firebase compatible, Kotlin 2.2.x/2.3.x maximum)
+                // Java 21 bytecode (Compatible with current JVM)
                 compileOptions {
-                    sourceCompatibility = JavaVersion.VERSION_24
-                    targetCompatibility = JavaVersion.VERSION_24
+                    sourceCompatibility = JavaVersion.VERSION_21
+                    targetCompatibility = JavaVersion.VERSION_21
 
                     isCoreLibraryDesugaringEnabled = true
                 }
@@ -135,10 +135,10 @@ class GenesisApplicationPlugin : Plugin<Project> {
                 }
             }
 
-            // Configure Kotlin compilation with JVM 24 target (Kotlin 2.2.x/2.3.x maximum)
+            // Configure Kotlin compilation with JVM 21 target
             tasks.withType<KotlinJvmCompile>().configureEach {
                 compilerOptions {
-                    jvmTarget.set(JvmTarget.JVM_24)
+                    jvmTarget.set(JvmTarget.JVM_21)
                     freeCompilerArgs.addAll(
                         "-opt-in=kotlin.RequiresOptIn",
                         "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",

--- a/build-logic/src/main/kotlin/GenesisLibraryHiltPlugin.kt
+++ b/build-logic/src/main/kotlin/GenesisLibraryHiltPlugin.kt
@@ -71,10 +71,10 @@ class GenesisLibraryHiltPlugin : Plugin<Project> {
                     }
                 }
 
-                // Java 24 bytecode (Firebase compatible, Kotlin max target)
+                // Java 21 bytecode (Compatible with current JVM)
                 compileOptions {
-                    sourceCompatibility = JavaVersion.VERSION_24
-                    targetCompatibility = JavaVersion.VERSION_24
+                    sourceCompatibility = JavaVersion.VERSION_21
+                    targetCompatibility = JavaVersion.VERSION_21
                     isCoreLibraryDesugaringEnabled = true
                 }
 
@@ -101,10 +101,10 @@ class GenesisLibraryHiltPlugin : Plugin<Project> {
                 }
             }
 
-            // Configure Kotlin compilation with JVM 24 target
+            // Configure Kotlin compilation with JVM 21 target
             tasks.withType<KotlinJvmCompile>().configureEach {
                 compilerOptions {
-                    jvmTarget.set(JvmTarget.JVM_24)
+                    jvmTarget.set(JvmTarget.JVM_21)
                     freeCompilerArgs.addAll(
                         "-opt-in=kotlin.RequiresOptIn",
                         "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
@@ -135,7 +135,7 @@ class GenesisLibraryHiltPlugin : Plugin<Project> {
             // Timber Logging
             dependencies.add("implementation", "com.jakewharton.timber:timber:5.0.1")
 
-            // Core Library Desugaring (for Java 24 APIs on older Android)
+            // Core Library Desugaring (for Java 21 APIs on older Android)
             dependencies.add("coreLibraryDesugaring", "com.android.tools:desugar_jdk_libs:2.1.5")
 
             // Universal Xposed/LSPosed API access for all library modules

--- a/build-logic/src/main/kotlin/GenesisLibraryPlugin.kt
+++ b/build-logic/src/main/kotlin/GenesisLibraryPlugin.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
  * - Android library plugin and extensions
  * - Kotlin Android support with Compose compiler
  * - Jetpack Compose (built-in compiler with Kotlin 2.0+)
- * - Java 24 bytecode target (Firebase compatible)
+ * - Java 21 bytecode target
  * - Consistent build configuration across library modules
  *
  * Plugin Application Order (Critical!):
@@ -38,7 +38,7 @@ class GenesisLibraryPlugin : Plugin<Project> {
      *
      * Configures plugins (applied in a prescribed order), the Android LibraryExtension (compile/NDK
      * settings, defaultConfig, build types, Java/compile options, build features, packaging, and lint),
-     * Kotlin compilation options (JVM 24 target and required opt-ins), and the convention's standard
+     * Kotlin compilation options (JVM 21 target and required opt-ins), and the convention's standard
      * dependencies.
      *
      * This method applies the external Kotlin Android plugin for compatibility and does not apply Hilt
@@ -79,10 +79,10 @@ class GenesisLibraryPlugin : Plugin<Project> {
                     }
                 }
 
-                // Java 24 bytecode (Firebase compatible, Kotlin max target)
+                // Java 21 bytecode (Compatible with current JVM)
                 compileOptions {
-                    sourceCompatibility = JavaVersion.VERSION_24
-                    targetCompatibility = JavaVersion.VERSION_24
+                    sourceCompatibility = JavaVersion.VERSION_21
+                    targetCompatibility = JavaVersion.VERSION_21
                     isCoreLibraryDesugaringEnabled = true
                 }
 
@@ -111,10 +111,10 @@ class GenesisLibraryPlugin : Plugin<Project> {
                 }
             }
 
-            // Configure Kotlin compilation with JVM 24 target (Kotlin 2.2.x/2.3.x maximum)
+            // Configure Kotlin compilation with JVM 21 target
             tasks.withType<KotlinJvmCompile>().configureEach {
                 compilerOptions {
-                    jvmTarget.set(JvmTarget.JVM_24)
+                    jvmTarget.set(JvmTarget.JVM_21)
                     freeCompilerArgs.addAll(
                         "-opt-in=kotlin.RequiresOptIn",
                         "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
@@ -142,7 +142,7 @@ class GenesisLibraryPlugin : Plugin<Project> {
             // Timber Logging
             dependencies.add("implementation", "com.jakewharton.timber:timber:5.0.1")
 
-            // Core Library Desugaring (for Java 24 APIs on older Android)
+            // Core Library Desugaring (for Java 21 APIs on older Android)
             dependencies.add("coreLibraryDesugaring", "com.android.tools:desugar_jdk_libs:2.1.5")
 
             // Universal Xposed/LSPosed API access for all library modules


### PR DESCRIPTION
The build-logic plugins were hardcoded to Java 24 bytecode targets, causing JVM version mismatch errors when building with Java 21.

Changes:
- GenesisApplicationPlugin: Java 24 → Java 21 (lines 25, 94-97, 138-141)
- GenesisLibraryPlugin: Java 24 → Java 21 (lines 21, 41, 82-85, 114-117, 145)
- GenesisLibraryHiltPlugin: Java 24 → Java 21 (lines 74-77, 104-107, 138)

Root cause: Convention plugins set bytecode target AND jvmTarget to VERSION_24/JVM_24, but build environment only has JVM 21 available.

Note: This allows the build to succeed with current JVM. If Firebase truly requires Java 24 bytecode (not just JVM 24 to run Gradle), we'll need to either:
1. Upgrade build environment to JVM 24
2. Use older Firebase SDK that supports Java 21
3. Verify if Firebase actually works with Java 21 target + desugaring

## Summary by Sourcery

Bug Fixes:
- Downgrade Java bytecode target and Kotlin jvmTarget from Java 24 to Java 21 in GenesisApplicationPlugin, GenesisLibraryPlugin, and GenesisLibraryHiltPlugin