### PR TITLE
Fix: Resolve build-logic variant attribute mismatch

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -3,15 +3,16 @@ plugins {
 }
 
 // Configure Kotlin compilation to match Java toolchain
+// MUST match the target used in GenesisApplicationPlugin and GenesisLibraryHiltPlugin (JVM 24)
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_24)
     }
 }
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(24))
     }
 }
 
@@ -39,7 +40,13 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.0-Beta2")
     implementation("org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.3.0-Beta2")
     implementation("org.jetbrains.kotlin:kotlin-serialization:2.3.0-Beta2")
-    implementation("com.google.dagger:hilt-android-gradle-plugin:2.57.2")
+
+    // Hilt Gradle Plugin - exclude Android runtime (AAR) dependencies
+    // build-logic is JVM-only and cannot consume Android AAR files
+    implementation("com.google.dagger:hilt-android-gradle-plugin:2.57.2") {
+        exclude(group = "com.google.dagger", module = "hilt-android")
+    }
+
     implementation("com.google.devtools.ksp:symbol-processing-gradle-plugin:2.3.2")
     implementation("com.google.gms:google-services:4.4.4")
 }


### PR DESCRIPTION
Two critical fixes to stop Java/JVM version reverting to 17/21:

1. **Java Toolchain: 21 → 24**
   - Updated build-logic to match GenesisApplicationPlugin/GenesisLibraryHiltPlugin
   - Prevents "compatible with Java 24" variant attribute errors
   - Stops recurring Java version reversion issue

2. **Exclude Android AAR from Hilt Gradle Plugin**
   - build-logic is JVM-only and cannot consume Android AAR files
   - Added exclude clause: hilt-android-gradle-plugin excludes hilt-android
   - Prevents androidx.activity/fragment/lifecycle AAR dependency resolution

Fixes variant selection errors:
- "library elements 'aar' and the consumer needed class files"
- "requires Java 24 compatibility" mismatches

Build-logic now compiles with correct JVM target and dependency variants.

## Summary by Sourcery

Ensure build-logic uses the correct JVM variant and prevents unsupported AAR dependencies to resolve variant attribute mismatches and recurring Java version reversion

Build:
- Bump Java toolchain and Kotlin JVM target from 21 to 24 to align with application and Hilt plugins
- Exclude the hilt-android runtime AAR module from the Hilt Gradle plugin to avoid Android AAR resolution in the JVM-only build-logic