### PR TITLE
Fix: Add comprehensive AndroidX exclusions for Hilt gradle plugin

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -42,10 +42,16 @@ dependencies {
     implementation("org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.3.0-Beta2")
     implementation("org.jetbrains.kotlin:kotlin-serialization:2.3.0-Beta2")
 
-    // Hilt Gradle Plugin - exclude Android runtime (AAR) dependencies
+    // Hilt Gradle Plugin - exclude ALL Android runtime (AAR) dependencies
     // build-logic is JVM-only and cannot consume Android AAR files
+    // Must exclude all AndroidX transitive dependencies pulled by hilt-android-gradle-plugin
     implementation("com.google.dagger:hilt-android-gradle-plugin:2.57.2") {
         exclude(group = "com.google.dagger", module = "hilt-android")
+        exclude(group = "androidx.activity")
+        exclude(group = "androidx.fragment")
+        exclude(group = "androidx.lifecycle")
+        exclude(group = "androidx.savedstate")
+        exclude(group = "androidx.annotation")
     }
 
     implementation("com.google.devtools.ksp:symbol-processing-gradle-plugin:2.3.2")


### PR DESCRIPTION
Extended the Hilt gradle plugin exclusions to block ALL AndroidX AAR dependencies:
- androidx.activity
- androidx.fragment
- androidx.lifecycle
- androidx.savedstate
- androidx.annotation

The previous fix only excluded hilt-android, but hilt-android-gradle-plugin has transitive dependencies on AndroidX libraries that are also AAR format.

build-logic is JVM-only and needs JAR (class files), not AAR format.

Resolves: androidx.savedstate:savedstate:1.2.0 variant mismatch error

## Summary by Sourcery

Extend Hilt plugin exclusions in the build-logic module to exclude all AndroidX AAR artifacts, ensuring only JVM-compatible JARs are consumed and resolving the variant mismatch error

Bug Fixes:
- Resolve variant mismatch error for androidx.savedstate:savedstate:1.2.0

Build:
- Broaden exclusions in build-logic.gradle.kts to block all AndroidX AAR dependencies from the Hilt Gradle plugin