### PR TITLE
Fix: Force exclude Android AAR deps from ALL build-logic configurations

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -2,6 +2,24 @@ plugins {
     `kotlin-dsl`        // applies java-gradle-plugin
 }
 
+// ═══════════════════════════════════════════════════════════════════════════
+// CRITICAL: Exclude ALL Android AAR dependencies from build-logic
+// ═══════════════════════════════════════════════════════════════════════════
+// build-logic is JVM-only and cannot consume Android AAR (Android Archive) files.
+// hilt-android-gradle-plugin incorrectly depends on hilt-android (runtime library),
+// which transitively pulls in AndroidX AAR dependencies.
+// Force exclude these from ALL configurations to prevent variant resolution errors.
+
+configurations.all {
+    exclude(group = "com.google.dagger", module = "hilt-android")
+    exclude(group = "androidx.activity")
+    exclude(group = "androidx.fragment")
+    exclude(group = "androidx.lifecycle")
+    exclude(group = "androidx.savedstate")
+    exclude(group = "androidx.annotation")
+    exclude(group = "androidx.core")
+}
+
 // Configure Kotlin compilation to match Java toolchain
 // MUST match the target used in GenesisApplicationPlugin and GenesisLibraryHiltPlugin (JVM 24)
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
@@ -42,17 +60,8 @@ dependencies {
     implementation("org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.3.0-Beta2")
     implementation("org.jetbrains.kotlin:kotlin-serialization:2.3.0-Beta2")
 
-    // Hilt Gradle Plugin - exclude ALL Android runtime (AAR) dependencies
-    // build-logic is JVM-only and cannot consume Android AAR files
-    // Must exclude all AndroidX transitive dependencies pulled by hilt-android-gradle-plugin
-    implementation("com.google.dagger:hilt-android-gradle-plugin:2.57.2") {
-        exclude(group = "com.google.dagger", module = "hilt-android")
-        exclude(group = "androidx.activity")
-        exclude(group = "androidx.fragment")
-        exclude(group = "androidx.lifecycle")
-        exclude(group = "androidx.savedstate")
-        exclude(group = "androidx.annotation")
-    }
+    // Hilt Gradle Plugin (Android AAR dependencies excluded globally via configurations.all)
+    implementation("com.google.dagger:hilt-android-gradle-plugin:2.57.2")
 
     implementation("com.google.devtools.ksp:symbol-processing-gradle-plugin:2.3.2")
     implementation("com.google.gms:google-services:4.4.4")


### PR DESCRIPTION
The previous per-dependency exclude() clauses weren't working because hilt-android-gradle-plugin declares hilt-android as a direct dependency, not a transitive one.

Solution: Use configurations.all {} to forcefully exclude Android AAR dependencies from ALL configurations in build-logic module.

Global exclusions:
- com.google.dagger:hilt-android
- androidx.activity
- androidx.fragment
- androidx.lifecycle
- androidx.savedstate
- androidx.annotation
- androidx.core

This prevents Gradle from even attempting to resolve AAR variants, which build-logic (JVM-only) cannot consume.

Resolves: "No matching variant" errors for androidx.savedstate:1.2.0

## Summary by Sourcery

Forcefully exclude Android AAR dependencies from all configurations in the build-logic module to prevent variant resolution errors in the JVM-only code.

Bug Fixes:
- Resolve ‘No matching variant’ errors by preventing Gradle from attempting to resolve Android AAR variants for hilt-android and AndroidX dependencies

Enhancements:
- Centralize exclusion of Android AAR dependencies into a configurations.all block
- Remove redundant per-dependency exclude clauses from the Hilt Gradle plugin declaration
- Add global exclusions for com.google.dagger:hilt-android and various AndroidX groups including androidx.core