### PR TITLE
Fix: AGP version mismatch (alpha13 → alpha14)

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,8 +11,8 @@ pluginManagement {
         maven { url = uri("https://jitpack.io") }
     }
     plugins {
-        id("com.android.application") version "9.0.0-alpha13" apply false
-        id("com.android.library") version "9.0.0-alpha13" apply false
+        id("com.android.application") version "9.0.0-alpha14" apply false
+        id("com.android.library") version "9.0.0-alpha14" apply false
         // Note: Using EXTERNAL kotlin-android plugin (android.builtInKotlin=false for Hilt compatibility)
         id("org.jetbrains.kotlin.android") version "2.3.0-Beta2" apply false
         id("org.jetbrains.kotlin.plugin.compose") version "2.3.0-Beta2" apply false


### PR DESCRIPTION
Resolved build error: "Using different versions of the Android Gradle plugin (9.0.0-alpha13, 9.0.0-alpha14) in the same build is not allowed."

Root cause:
- settings.gradle.kts declared AGP 9.0.0-alpha13
- build-logic/build.gradle.kts uses AGP 9.0.0-alpha14
- AGP enforces strict version consistency across entire build

Solution:
Updated settings.gradle.kts to match build-logic's alpha14 version.

This fixes module build errors like in extendsysb where the genesis convention plugins (which use alpha14) couldn't be applied because the module inherited alpha13 from settings.gradle.kts.

## Summary by Sourcery

Bug Fixes:
- Bump com.android.application and com.android.library plugin versions from 9.0.0-alpha13 to 9.0.0-alpha14 to resolve build errors due to version mismatch