### PR TITLE
Fix: Migrate to AGP 9.0 built-in Kotlin support

### DIFF
--- a/build-logic/src/main/kotlin/GenesisApplicationPlugin.kt
+++ b/build-logic/src/main/kotlin/GenesisApplicationPlugin.kt
@@ -26,13 +26,12 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
  * - Consistent build configuration across app modules
  *
  * Plugin Application Order (Critical!):
- * 1. com.android.application
- * 2. org.jetbrains.kotlin.android
- * 3. org.jetbrains.kotlin.plugin.compose (Built-in Compose compiler)
- * 4. com.google.dagger.hilt.android
- * 5. com.google.devtools.ksp
- * 6. org.jetbrains.kotlin.plugin.serialization
- * 7. com.google.gms.google-services
+ * 1. com.android.application (provides built-in Kotlin since AGP 9.0)
+ * 2. org.jetbrains.kotlin.plugin.compose (Built-in Compose compiler)
+ * 3. com.google.dagger.hilt.android
+ * 4. com.google.devtools.ksp
+ * 5. org.jetbrains.kotlin.plugin.serialization
+ * 6. com.google.gms.google-services
  *
  * @since Genesis Protocol 2.0 (AGP 9.0.0-alpha14 Compatible)
  */
@@ -51,9 +50,8 @@ class GenesisApplicationPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         with(project) {
             // Apply plugins in correct order
-            // Note: Using EXTERNAL kotlin-android plugin (android.builtInKotlin=false for Hilt compatibility)
+            // Note: Kotlin is built into AGP 9.0.0-alpha14+ (android.builtInKotlin=true)
             pluginManager.apply("com.android.application")
-            pluginManager.apply("org.jetbrains.kotlin.android")
             pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
             pluginManager.apply("com.google.dagger.hilt.android")
             pluginManager.apply("com.google.devtools.ksp")

--- a/build-logic/src/main/kotlin/GenesisLibraryHiltPlugin.kt
+++ b/build-logic/src/main/kotlin/GenesisLibraryHiltPlugin.kt
@@ -19,12 +19,11 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
  * - KSP annotation processing for Hilt
  *
  * Plugin Application Order (Critical!):
- * 1. com.android.library
- * 2. org.jetbrains.kotlin.android
- * 3. org.jetbrains.kotlin.plugin.compose
- * 4. com.google.dagger.hilt.android (HILT - only in this variant)
- * 5. com.google.devtools.ksp (KSP - only in this variant)
- * 6. org.jetbrains.kotlin.plugin.serialization
+ * 1. com.android.library (provides built-in Kotlin since AGP 9.0)
+ * 2. org.jetbrains.kotlin.plugin.compose
+ * 3. com.google.dagger.hilt.android (HILT - only in this variant)
+ * 4. com.google.devtools.ksp (KSP - only in this variant)
+ * 5. org.jetbrains.kotlin.plugin.serialization
  *
  * Usage:
  * plugins {
@@ -40,9 +39,8 @@ class GenesisLibraryHiltPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         with(project) {
             // Apply plugins in correct order
-            // Note: Using EXTERNAL kotlin-android plugin (android.builtInKotlin=false for Hilt compatibility)
+            // Note: Kotlin is built into AGP 9.0.0-alpha14+ (android.builtInKotlin=true)
             pluginManager.apply("com.android.library")
-            pluginManager.apply("org.jetbrains.kotlin.android")
             pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
             pluginManager.apply("com.google.dagger.hilt.android")  // ← HILT PLUGIN
             pluginManager.apply("com.google.devtools.ksp")         // ← KSP FOR HILT

--- a/build-logic/src/main/kotlin/GenesisLibraryPlugin.kt
+++ b/build-logic/src/main/kotlin/GenesisLibraryPlugin.kt
@@ -22,13 +22,12 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
  * - Consistent build configuration across library modules
  *
  * Plugin Application Order (Critical!):
- * 1. com.android.library
- * 2. org.jetbrains.kotlin.android
- * 3. org.jetbrains.kotlin.plugin.compose (Built-in Compose compiler)
- * 4. org.jetbrains.kotlin.plugin.serialization
+ * 1. com.android.library (provides built-in Kotlin since AGP 9.0)
+ * 2. org.jetbrains.kotlin.plugin.compose (Built-in Compose compiler)
+ * 3. org.jetbrains.kotlin.plugin.serialization
  *
- * Note: Hilt and KSP are NOT applied in library modules per AGP 9.0 workaround.
- * Individual library modules that need Hilt should apply it explicitly
+ * Note: Kotlin is built into AGP 9.0.0-alpha14+ (android.builtInKotlin=true)
+ * Note: Hilt and KSP are NOT applied - use genesis.android.library.hilt for DI
  *
  * @since Genesis Protocol 2.0 (AGP 9.0.0-alpha14 Compatible)
  */
@@ -41,7 +40,7 @@ class GenesisLibraryPlugin : Plugin<Project> {
      * Kotlin compilation options (JVM 24 target and required opt-ins), and the convention's standard
      * dependencies.
      *
-     * This method applies the external Kotlin Android plugin for compatibility and does not apply Hilt
+     * This method configures the Android library extension and does not apply Hilt
      * or KSP; library modules should opt into Hilt explicitly if required.
      *
      * @param project The Gradle project to configure.
@@ -49,10 +48,9 @@ class GenesisLibraryPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         with(project) {
             // Apply plugins in correct order
-            // Note: Using EXTERNAL kotlin-android plugin (android.builtInKotlin=false for Hilt compatibility)
-            // Note: Hilt NOT applied here - library modules apply it explicitly if needed per AGP 9.0 workaround
+            // Note: Kotlin is built into AGP 9.0.0-alpha14+ (android.builtInKotlin=true)
+            // Note: Hilt NOT applied - use genesis.android.library.hilt for DI
             pluginManager.apply("com.android.library")
-            pluginManager.apply("org.jetbrains.kotlin.android")
             pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
             pluginManager.apply("org.jetbrains.kotlin.plugin.serialization")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,12 +24,11 @@ kotlin.incremental=true
 android.optimize.build=true
 android.enableDesugaring=true
 
-# ===== CRITICAL: AGP 9.0 + Hilt Compatibility (Genesis Protocol Solution) =====
-# Documented in: context/docs/AGP9_HILT_COMPATIBILITY_GUIDE.md
-# The key breakthrough: Force external Kotlin plugin instead of AGP 9.0's built-in
+# ===== CRITICAL: AGP 9.0 Configuration =====
+# AGP 9.0.0-alpha14+ requires built-in Kotlin support (external Kotlin plugin no longer allowed)
 android.newDsl=false
-android.builtInKotlin=false
-kotlin.builtInKotlin=false
+android.builtInKotlin=true
+kotlin.builtInKotlin=true
 android.disableLastStageWhenHiltIsApplied=true
 # Compose Configuration
 android.compose.experimentalStrongSkippingEnabled=true


### PR DESCRIPTION
Resolved error: "The 'org.jetbrains.kotlin.android' plugin is no longer required for Kotlin support since AGP 9.0"

Changes:
1. gradle.properties: Set android.builtInKotlin=true (was false)
2. GenesisApplicationPlugin: Removed kotlin.android plugin application
3. GenesisLibraryPlugin: Removed kotlin.android plugin application
4. GenesisLibraryHiltPlugin: Removed kotlin.android plugin application

AGP 9.0.0-alpha14+ includes Kotlin natively, making the external kotlin-android plugin both unnecessary and forbidden. Convention plugins now rely on AGP's built-in Kotlin support while still applying Compose and Serialization plugins.

This completes the AGP 9.0 migration after fixing:
- AGP version mismatch (alpha13 → alpha14)
- Build-logic Java toolchain (21 → 24)
- Android AAR dependency exclusions

Modules can now successfully use genesis.android.library plugins.

## Summary by Sourcery

Migrate build logic to AGP 9.0's built-in Kotlin support by enabling built-in Kotlin in properties and removing the external kotlin-android plugin from convention plugins.

Enhancements:
- Enable AGP 9.0 built-in Kotlin support by setting android.builtInKotlin and kotlin.builtInKotlin to true in gradle.properties
- Remove external org.jetbrains.kotlin.android plugin application from GenesisApplicationPlugin, GenesisLibraryPlugin, and GenesisLibraryHiltPlugin
- Update plugin application order and documentation comments in convention plugins to reflect built-in Kotlin and current AGP 9.0 requirements

Build:
- Update gradle.properties to activate AGP 9.0 built-in Kotlin support and remove legacy external Kotlin plugin flags