### PR TITLE
Copilot/sub pr 165 again

### DIFF
--- a/genesis/oracledrive/rootmanagement/build.gradle.kts
+++ b/genesis/oracledrive/rootmanagement/build.gradle.kts
@@ -2,8 +2,7 @@
 // ROM Tools Module - System and ROM modification utilities
 // ═══════════════════════════════════════════════════════════════════════════
 plugins {
-    id("genesis.android.library")
-    id("com.google.devtools.ksp")  // Required for YukiHook annotation processing
+    id("genesis.android.library.hilt")  // Provides Hilt + KSP for DI and YukiHook
 }
 
 android {
@@ -25,12 +24,13 @@ android {
 
 dependencies {
     // ═══════════════════════════════════════════════════════════════════════
-    // AUTO-PROVIDED by genesis.android.library:
+    // AUTO-PROVIDED by genesis.android.library.hilt:
     // - androidx-core-ktx, appcompat, timber
     // - Hilt (android + compiler via KSP)
     // - Coroutines (core + android)
     // - Compose enabled by default
     // - Java 24 bytecode target
+    // - KSP plugin for annotation processing
     // ═══════════════════════════════════════════════════════════════════════
 
     // Expose core KTX as API


### PR DESCRIPTION
## Summary by Sourcery

Consolidate plugin configuration by replacing separate android.library and KSP plugins with the unified genesis.android.library.hilt plugin

Build:
- Replace genesis.android.library and com.google.devtools.ksp plugins with genesis.android.library.hilt
- Update auto-provided dependencies comments to include the KSP plugin