### PR TITLE
Refactor: Centralize JVM toolchain configuration in convention plugins

### DIFF
--- a/build-logic/src/main/kotlin/GenesisApplicationPlugin.kt
+++ b/build-logic/src/main/kotlin/GenesisApplicationPlugin.kt
@@ -4,10 +4,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 /**
  * ===================================================================
@@ -133,22 +129,8 @@ class GenesisApplicationPlugin : Plugin<Project> {
                 }
             }
 
-            // Configure Kotlin JVM toolchain to match Java toolchain (uses foojay-resolver)
-            extensions.configure<KotlinAndroidProjectExtension> {
-                jvmToolchain(24)
-            }
-
-            // Configure Kotlin compilation with JVM 24 target (Kotlin 2.2.x/2.3.x maximum)
-            tasks.withType<KotlinJvmCompile>().configureEach {
-                compilerOptions {
-                    jvmTarget.set(JvmTarget.JVM_24)
-                    freeCompilerArgs.addAll(
-                        "-opt-in=kotlin.RequiresOptIn",
-                        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-                        "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api"
-                    )
-                }
-            }
+            // Configure Kotlin JVM toolchain and compilation options
+            GenesisJvmConfig.configureKotlinJvm(project)
 
             // ═══════════════════════════════════════════════════════════════════════════
             // Auto-configured dependencies (provided by convention plugin)

--- a/build-logic/src/main/kotlin/GenesisJvmConfig.kt
+++ b/build-logic/src/main/kotlin/GenesisJvmConfig.kt
@@ -1,0 +1,67 @@
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
+/**
+ * ===================================================================
+ * GENESIS JVM CONFIGURATION
+ * ===================================================================
+ *
+ * Centralized JVM toolchain and compilation configuration for all Genesis modules.
+ *
+ * This object provides:
+ * - Single source of truth for JVM version across all modules
+ * - Shared utility functions for configuring Kotlin JVM toolchain
+ * - Consistent compiler options across all convention plugins
+ *
+ * @since Genesis Protocol 2.0 (AGP 9.0.0-alpha14 Compatible)
+ */
+object GenesisJvmConfig {
+    /**
+     * The JVM version used throughout the Genesis project.
+     *
+     * Java 24 bytecode is:
+     * - Firebase compatible
+     * - Maximum target supported by Kotlin 2.2.x/2.3.x
+     * - Enables modern Java features with backward compatibility via desugaring
+     */
+    const val JVM_VERSION = 24
+
+    /**
+     * Configures the Kotlin JVM toolchain for the given project.
+     *
+     * This sets up:
+     * - JVM toolchain version matching the project's Java version
+     * - Automatic JVM target selection (no manual jvmTarget.set() needed)
+     * - Compiler opt-ins for commonly used experimental APIs
+     *
+     * Note: jvmToolchain() automatically sets the correct jvmTarget, so explicit
+     * jvmTarget.set() calls are redundant and should be removed.
+     *
+     * @param project The Gradle project to configure
+     */
+    fun configureKotlinJvm(project: Project) {
+        with(project) {
+            // Configure Kotlin JVM toolchain to match Java toolchain (uses foojay-resolver)
+            // This automatically sets jvmTarget, making manual jvmTarget.set() redundant
+            extensions.configure<KotlinAndroidProjectExtension> {
+                jvmToolchain(JVM_VERSION)
+            }
+
+            // Configure Kotlin compilation options with opt-ins
+            tasks.withType<KotlinJvmCompile>().configureEach {
+                compilerOptions {
+                    // Note: jvmTarget is automatically set by jvmToolchain() above
+                    // Manual jvmTarget.set(JvmTarget.JVM_24) is redundant
+                    freeCompilerArgs.addAll(
+                        "-opt-in=kotlin.RequiresOptIn",
+                        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+                        "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/GenesisLibraryHiltPlugin.kt
+++ b/build-logic/src/main/kotlin/GenesisLibraryHiltPlugin.kt
@@ -3,10 +3,6 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 /**
  * ===================================================================
@@ -105,22 +101,8 @@ class GenesisLibraryHiltPlugin : Plugin<Project> {
                 }
             }
 
-            // Configure Kotlin JVM toolchain to match Java toolchain (uses foojay-resolver)
-            extensions.configure<KotlinAndroidProjectExtension> {
-                jvmToolchain(24)
-            }
-
-            // Configure Kotlin compilation with JVM 24 target
-            tasks.withType<KotlinJvmCompile>().configureEach {
-                compilerOptions {
-                    jvmTarget.set(JvmTarget.JVM_24)
-                    freeCompilerArgs.addAll(
-                        "-opt-in=kotlin.RequiresOptIn",
-                        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-                        "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api"
-                    )
-                }
-            }
+            // Configure Kotlin JVM toolchain and compilation options
+            GenesisJvmConfig.configureKotlinJvm(project)
 
             // ═══════════════════════════════════════════════════════════════════════════
             // Auto-configured dependencies (provided by convention plugin)

--- a/build-logic/src/main/kotlin/GenesisLibraryPlugin.kt
+++ b/build-logic/src/main/kotlin/GenesisLibraryPlugin.kt
@@ -3,10 +3,6 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 /**
  * ===================================================================
@@ -110,22 +106,8 @@ class GenesisLibraryPlugin : Plugin<Project> {
                 }
             }
 
-            // Configure Kotlin JVM toolchain to match Java toolchain (uses foojay-resolver)
-            extensions.configure<KotlinAndroidProjectExtension> {
-                jvmToolchain(24)
-            }
-
-            // Configure Kotlin compilation with JVM 24 target (Kotlin 2.2.x/2.3.x maximum)
-            tasks.withType<KotlinJvmCompile>().configureEach {
-                compilerOptions {
-                    jvmTarget.set(JvmTarget.JVM_24)
-                    freeCompilerArgs.addAll(
-                        "-opt-in=kotlin.RequiresOptIn",
-                        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-                        "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api"
-                    )
-                }
-            }
+            // Configure Kotlin JVM toolchain and compilation options
+            GenesisJvmConfig.configureKotlinJvm(project)
 
             // ═══════════════════════════════════════════════════════════════════════════
             // Auto-configured dependencies (provided by convention plugin)


### PR DESCRIPTION
**Changes:**
- Create `GenesisJvmConfig` object as single source of truth for JVM version
- Extract repeated `jvmToolchain(24)` configuration into shared utility function
- Remove redundant `jvmTarget.set(JvmTarget.JVM_24)` calls (automatically set by jvmToolchain)
- Update all three convention plugins to use centralized configuration:
  - GenesisApplicationPlugin
  - GenesisLibraryPlugin
  - GenesisLibraryHiltPlugin

**Benefits:**
- Eliminates code duplication across convention plugins
- Centralizes JVM version constant for easier future updates
- Simplifies configuration by removing redundant jvmTarget settings
- Improves maintainability with single source of truth

**Technical Details:**
- JVM version 24 is stored in `GenesisJvmConfig.JVM_VERSION` constant
- `GenesisJvmConfig.configureKotlinJvm()` handles both toolchain and compiler options
- Removed unused imports (JvmTarget, KotlinAndroidProjectExtension, KotlinJvmCompile)

## Summary by Sourcery

Centralize JVM toolchain and Kotlin compilation settings into a shared configuration object and update convention plugins to use it

Enhancements:
- Introduce GenesisJvmConfig to define a single JVM_VERSION constant and configure Kotlin JVM toolchain and compiler options
- Refactor GenesisApplicationPlugin, GenesisLibraryPlugin, and GenesisLibraryHiltPlugin to invoke GenesisJvmConfig.configureKotlinJvm instead of duplicating toolchain setup
- Remove redundant manual jvmTarget settings and related imports from the convention plugins