### PR TITLE
Fix: Resolve KSP unresolved reference errors by enabling Hilt in all …

### DIFF
--- a/aura/reactivedesign/chromacore/build.gradle.kts
+++ b/aura/reactivedesign/chromacore/build.gradle.kts
@@ -2,8 +2,7 @@
 // Color Blendr Module - Color blending and theming utilities
 // ═══════════════════════════════════════════════════════════════════════════
 plugins {
-    id("genesis.android.library.hilt")
-    alias(libs.plugins.ksp)  // Required for YukiHook code generation
+    id("genesis.android.library.hilt")  // KSP already included in Hilt plugin
 }
 
 android {

--- a/aura/reactivedesign/chromacore/src/main/datavein-oracle-native/src/main/kotlin/dev/aurakai/auraframefx/datavein/ui/DataVeinSphereGridViewModel.kt
+++ b/aura/reactivedesign/chromacore/src/main/datavein-oracle-native/src/main/kotlin/dev/aurakai/auraframefx/datavein/ui/DataVeinSphereGridViewModel.kt
@@ -1,7 +1,6 @@
 package dev.aurakai.auraframefx.datavein.ui
 
-// Temporarily removed Hilt to resolve build issues
-// import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.aurakai.auraframefx.datavein.model.DataVeinNode
@@ -16,16 +15,15 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-
-// import javax.inject.Inject
+import javax.inject.Inject
 
 /**
  * ViewModel for managing DataVein Sphere Grid state
  * Handles node interactions, progression, and real-time updates
- * Note: Hilt integration temporarily disabled for build resolution
+ * Now using Hilt dependency injection
  */
-// @HiltViewModel
-class DataVeinSphereGridViewModel /* @Inject constructor() */ : ViewModel() {
+@HiltViewModel
+class DataVeinSphereGridViewModel @Inject constructor() : ViewModel() {
 
     private val _selectedNode = MutableStateFlow<DataVeinNode?>(null)
     val selectedNode: StateFlow<DataVeinNode?> = _selectedNode.asStateFlow()

--- a/aura/reactivedesign/collabcanvas/build.gradle.kts
+++ b/aura/reactivedesign/collabcanvas/build.gradle.kts
@@ -2,8 +2,7 @@
 // Collaborative Canvas Module - Real-time collaborative drawing/whiteboard
 // ═══════════════════════════════════════════════════════════════════════════
 plugins {
-    id("genesis.android.library")
-    alias(libs.plugins.ksp)  // Required for Hilt + Room code generation
+    id("genesis.android.library.hilt")  // Use Hilt-enabled variant for dependency injection
 
 }
 

--- a/genesis/oracledrive/datavein/build.gradle.kts
+++ b/genesis/oracledrive/datavein/build.gradle.kts
@@ -2,8 +2,7 @@
 // DataVein Oracle Native Module - Native Oracle cloud data access
 // ═══════════════════════════════════════════════════════════════════════════
 plugins {
-    id("genesis.android.library")
-    alias(libs.plugins.ksp)  // Required for Hilt + Room code generation
+    id("genesis.android.library.hilt")  // Use Hilt-enabled variant for dependency injection
 
 }
 

--- a/genesis/oracledrive/datavein/src/main/kotlin/dev/aurakai/auraframefx/datavein/ui/DataVeinSphereGridViewModel.kt
+++ b/genesis/oracledrive/datavein/src/main/kotlin/dev/aurakai/auraframefx/datavein/ui/DataVeinSphereGridViewModel.kt
@@ -1,7 +1,6 @@
 package dev.aurakai.auraframefx.datavein.ui
 
-// Temporarily removed Hilt to resolve build issues
-// import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.aurakai.auraframefx.datavein.model.DataVeinNode
@@ -16,16 +15,15 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-
-// import javax.inject.Inject
+import javax.inject.Inject
 
 /**
  * ViewModel for managing DataVein Sphere Grid state
  * Handles node interactions, progression, and real-time updates
- * Note: Hilt integration temporarily disabled for build resolution
+ * Now using Hilt dependency injection
  */
-// @HiltViewModel
-class DataVeinSphereGridViewModel /* @Inject constructor() */ : ViewModel() {
+@HiltViewModel
+class DataVeinSphereGridViewModel @Inject constructor() : ViewModel() {
 
     private val _selectedNode = MutableStateFlow<DataVeinNode?>(null)
     val selectedNode: StateFlow<DataVeinNode?> = _selectedNode.asStateFlow()

--- a/genesis/oracledrive/rootmanagement/build.gradle.kts
+++ b/genesis/oracledrive/rootmanagement/build.gradle.kts
@@ -5,8 +5,7 @@ import org.jetbrains.kotlin.gradle.idea.proto.com.google.protobuf.LazyStringArra
 // ROM Tools Module - System and ROM modification utilities
 // ═══════════════════════════════════════════════════════════════════════════
 plugins {
-    id("genesis.android.library")
-    alias(libs.plugins.ksp)  // Required for Hilt + Room code generation
+    id("genesis.android.library.hilt")  // Use Hilt-enabled variant for dependency injection
 
 }
 

--- a/kai/sentinelsfortress/security/build.gradle.kts
+++ b/kai/sentinelsfortress/security/build.gradle.kts
@@ -2,8 +2,7 @@
 // Secure Communication Module - Encrypted communication layer
 // ═══════════════════════════════════════════════════════════════════════════
 plugins {
-    id("genesis.android.library")
-    alias(libs.plugins.ksp)  // Required for Hilt + Room code generation
+    id("genesis.android.library.hilt")  // Use Hilt-enabled variant for dependency injection
 
 }
 


### PR DESCRIPTION
…dependent modules

This commit fixes all KSP (Kotlin Symbol Processing) unresolved reference errors across the codebase by ensuring modules using Hilt annotations have the correct convention plugin configuration.

Changes:
- Updated 4 modules to use 'genesis.android.library.hilt' plugin:
  * genesis/oracledrive/datavein
  * kai/sentinelsfortress/security
  * genesis/oracledrive/rootmanagement
  * aura/reactivedesign/collabcanvas

- Re-enabled Hilt annotations in DataVeinSphereGridViewModel:
  * Restored @HiltViewModel annotation
  * Restored @Inject constructor
  * Fixed both main instance and backup in chromacore

- Removed duplicate KSP plugin declaration in chromacore module (KSP already included in genesis.android.library.hilt)

Technical Context:
The 'genesis.android.library.hilt' convention plugin automatically applies:
- com.google.dagger.hilt.android plugin
- com.google.devtools.ksp plugin
- Hilt dependencies (android + compiler via KSP)

This ensures all @HiltViewModel, @Inject, and @Singleton annotations are properly processed by KSP, resolving all unresolved reference errors.

Related to Genesis Protocol build system standardization.

## Summary by Sourcery

Enable Hilt and KSP processing across dependent modules to resolve Kotlin Symbol Processing unresolved reference errors for Hilt annotations.

Bug Fixes:
- Resolve KSP unresolved reference errors for Hilt annotations across the codebase

Enhancements:
- Re-enable @HiltViewModel annotation and @Inject constructors in DataVeinSphereGridViewModel implementations

Build:
- Switch four modules (datavein, security, rootmanagement, collabcanvas) to use the genesis.android.library.hilt plugin and remove manual KSP declarations