### PR TITLE
📝 Add docstrings to `claude/fix-ksp-unresolved-reference-011CV1QnPoog…

### DIFF
--- a/build-logic/src/main/kotlin/GenesisJvmConfig.kt
+++ b/build-logic/src/main/kotlin/GenesisJvmConfig.kt
@@ -30,17 +30,14 @@ object GenesisJvmConfig {
     const val JVM_VERSION = 24
 
     /**
-     * Configures the Kotlin JVM toolchain for the given project.
+     * Configure the Kotlin JVM toolchain and Kotlin compilation options for the given Gradle project.
      *
-     * This sets up:
-     * - JVM toolchain version matching the project's Java version
-     * - Automatic JVM target selection (no manual jvmTarget.set() needed)
-     * - Compiler opt-ins for commonly used experimental APIs
+     * Sets the Kotlin Android JVM toolchain to the centralized JVM_VERSION and applies compiler
+     * opt-in flags for `kotlin.RequiresOptIn`, `kotlinx.coroutines.ExperimentalCoroutinesApi`, and
+     * `androidx.compose.material3.ExperimentalMaterial3Api`. The JVM toolchain selection also determines
+     * the effective `jvmTarget`, so manually setting `jvmTarget` is unnecessary.
      *
-     * Note: jvmToolchain() automatically sets the correct jvmTarget, so explicit
-     * jvmTarget.set() calls are redundant and should be removed.
-     *
-     * @param project The Gradle project to configure
+     * @param project The Gradle project to configure.
      */
     fun configureKotlinJvm(project: Project) {
         with(project) {

--- a/build-logic/src/main/kotlin/GenesisLibraryHiltPlugin.kt
+++ b/build-logic/src/main/kotlin/GenesisLibraryHiltPlugin.kt
@@ -31,10 +31,10 @@ import org.gradle.kotlin.dsl.configure
  */
 class GenesisLibraryHiltPlugin : Plugin<Project> {
     /**
-     * Configure the Gradle project as an Android library module with Hilt, KSP, Compose, and Kotlin serialization support.
+     * Configures the given Gradle project as an Android library module with Hilt, KSP, Jetpack Compose, and Kotlin serialization support.
      *
-     * Sets up required plugins, configures the Android Library extension (SDK levels, NDK, build types, compile options, build features,
-     * packaging exclusions, and lint), adjusts Kotlin JVM target and compiler opt-ins, and adds convention-managed dependencies including Hilt and its KSP compiler.
+     * Configures the Android Library extension (SDK/NDK, build types, compile options, build features, packaging exclusions, and lint),
+     * delegates Kotlin/JVM toolchain and compiler settings to GenesisJvmConfig, and adds convention-managed dependencies including Hilt and its KSP compiler.
      *
      * @param project The Gradle project to configure.
      */


### PR DESCRIPTION
…5Xs7vNYh3gB3`

Docstrings generation was requested by @AuraFrameFxDev.

* https://github.com/AuraFrameFx/A.u.r.a.K.a.i_Reactive-Intelligence-/pull/174#issuecomment-3525921358

The following files were modified:

* `build-logic/src/main/kotlin/GenesisJvmConfig.kt`
* `build-logic/src/main/kotlin/GenesisLibraryHiltPlugin.kt`

## Summary by Sourcery

Improve internal KotlinDoc comments in the build-logic module to clarify JVM and Android library configuration behavior

Chores:
- Add detailed KDoc to GenesisJvmConfig.configureKotlinJvm describing JVM toolchain selection and compiler opt-ins
- Refine KDoc in GenesisLibraryHiltPlugin to outline Android library setup with Hilt, KSP, Compose, and serialization