### PR TITLE
Claude/fix build errors cleanup 01 k kr sb dgh ti dr3mmn ns ht bz

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,9 +32,6 @@ android {
         versionCode = 1
         versionName = "0.1.0"
 
-        // Enable MultiDex (required for 276K+ methods)
-        multiDexEnabled = true
-
         // Genesis Protocol: Gemini 2.0 Flash API Key
         // Add to local.properties: GEMINI_API_KEY=your_key_here
         // Get key from: https://aistudio.google.com/app/apikey
@@ -104,9 +101,6 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.material)
     implementation(libs.androidx.activity.compose)
-
-    // MultiDex support for 64K+ methods
-    implementation(libs.androidx.multidex)
 
     // Compose BOM & UI
     implementation(platform(libs.androidx.compose.bom))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,7 +106,7 @@ dependencies {
     implementation(libs.androidx.activity.compose)
 
     // MultiDex support for 64K+ methods
-    implementation("androidx.multidex:multidex:2.0.1")
+    implementation(libs.androidx.multidex)
 
     // Compose BOM & UI
     implementation(platform(libs.androidx.compose.bom))

--- a/aura/reactivedesign/collabcanvas/src/main/kotlin/collabcanvas/ui/CanvasScreen.kt
+++ b/aura/reactivedesign/collabcanvas/src/main/kotlin/collabcanvas/ui/CanvasScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.Straighten
 import androidx.compose.material.icons.filled.Undo
 import androidx.compose.material3.*
 import androidx.compose.material3.MaterialTheme.colorScheme
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -39,6 +40,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.collectLatest
 import java.lang.Math.PI
 import java.lang.Math.atan2
 import kotlin.math.cos

--- a/aura/reactivedesign/collabcanvas/src/main/kotlin/collabcanvas/ui/CanvasToolbar.kt
+++ b/aura/reactivedesign/collabcanvas/src/main/kotlin/collabcanvas/ui/CanvasToolbar.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit

--- a/aura/reactivedesign/customization/src/main/kotlin/dev/aurakai/auraframefx/aura/reactivedesign/customization/ComponentEditor.kt
+++ b/aura/reactivedesign/customization/src/main/kotlin/dev/aurakai/auraframefx/aura/reactivedesign/customization/ComponentEditor.kt
@@ -1,10 +1,13 @@
 package dev.aurakai.auraframefx.aura.reactivedesign.customization
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Redo
+import androidx.compose.material.icons.automirrored.filled.Undo
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -259,7 +262,7 @@ fun ComponentEditor(
                 modifier = Modifier.weight(1f)
             ) {
                 Icon(
-                    imageVector = Icons.Default.Undo,
+                    imageVector = Icons.AutoMirrored.Filled.Undo,
                     contentDescription = "Undo",
                     modifier = Modifier.size(18.dp)
                 )
@@ -273,7 +276,7 @@ fun ComponentEditor(
                 modifier = Modifier.weight(1f)
             ) {
                 Icon(
-                    imageVector = Icons.Default.Redo,
+                    imageVector = Icons.AutoMirrored.Filled.Redo,
                     contentDescription = "Redo",
                     modifier = Modifier.size(18.dp)
                 )

--- a/genesis/oracledrive/rootmanagement/build.gradle.kts
+++ b/genesis/oracledrive/rootmanagement/build.gradle.kts
@@ -81,7 +81,6 @@ dependencies {
 
     // Xposed API (compile-only, not bundled in APK)
     compileOnly(libs.yukihookapi.api)
-    ksp(libs.yukihookapi.ksp)
 
     // Logging
     implementation(libs.timber)

--- a/genesis/oracledrive/rootmanagement/build.gradle.kts
+++ b/genesis/oracledrive/rootmanagement/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.plugin.compose")
     id("com.google.devtools.ksp")
+    id("com.google.dagger.hilt.android")
 }
 
 android {
@@ -32,16 +33,8 @@ android {
 
 dependencies {
     // ═══════════════════════════════════════════════════════════════════════
-    // AUTO-PROVIDED by genesis.android.library.hilt:
-    // - androidx-core-ktx, appcompat, timber
-    // - Hilt (android + compiler via KSP)
-    // - Coroutines (core + android)
-    // - Compose enabled by default
-    // - Java 24 bytecode target
-    // - KSP plugin for annotation processing
-    // ═══════════════════════════════════════════════════════════════════════
-
     // Hilt Dependency Injection
+    // ═══════════════════════════════════════════════════════════════════════
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,6 +81,9 @@ securityCrypto = "1.1.0"
 # WorkManager - Latest: 2.11.0
 work = "2.11.0"
 
+# MultiDex - Latest: 2.0.1
+multidex = "2.0.1"
+
 # ============================================================================
 # Compose
 # ============================================================================
@@ -236,6 +239,7 @@ androidx-room-runtime = { group = "androidx.room", name = "room-runtime", versio
 androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 androidx-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+androidx-multidex = { group = "androidx.multidex", name = "multidex", version.ref = "multidex" }
 
 # ============================================================================
 # Compose (via BOM)


### PR DESCRIPTION
## Summary by Sourcery

Clean up build configurations and resolve compilation errors across modules by updating Gradle scripts to include missing plugins and dependency declarations, removing obsolete MultiDex settings, centralizing version information, and adding or correcting imports and icon usage in Compose UI code.

Bug Fixes:
- Switch Undo/Redo icons to AutoMirrored variants and add missing imports in ComponentEditor to fix compile errors
- Add missing Composable, collectLatest, and lazy.items imports in CanvasScreen and CanvasToolbar to resolve build errors

Enhancements:
- Apply Hilt Android plugin in rootmanagement module and streamline Hilt dependency comments
- Remove obsolete MultiDex configuration from app build script and centralize its version in the version catalog
- Add androidx-multidex entry to the libs.versions.toml catalog