### PR TITLE
Claude/fix build errors cleanup 01 k kr sb dgh ti dr3mmn ns ht bz

### DIFF
--- a/aura/reactivedesign/collabcanvas/src/main/kotlin/collabcanvas/ui/CanvasScreen.kt
+++ b/aura/reactivedesign/collabcanvas/src/main/kotlin/collabcanvas/ui/CanvasScreen.kt
@@ -140,8 +140,8 @@ fun CanvasScreen(
                             when (currentTool) {
                                 DrawingTool.PEN, DrawingTool.ERASER, DrawingTool.HIGHLIGHTER -> {
                                     currentPath?.let { path ->
-                                        val op: Unit = DrawingOperation.PathOp(
-                                            path = android.graphics.Path(path),
+                                        val op = DrawingOperation.PathOp(
+                                            path = path,
                                             color = if (currentTool == DrawingTool.ERASER)
                                                 colorScheme.background else currentColor,
                                             strokeWidth = if (currentTool == DrawingTool.HIGHLIGHTER)
@@ -342,7 +342,7 @@ fun CanvasScreen(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                items(DrawingTool.values()) { tool ->
+                items(DrawingTool.entries) { tool ->
                     val isSelected = currentTool == tool
                     val tint = if (isSelected) colorScheme.primary else colorScheme.onSurfaceVariant
 

--- a/aura/reactivedesign/customization/src/main/kotlin/dev/aurakai/auraframefx/aura/reactivedesign/customization/ComponentEditor.kt
+++ b/aura/reactivedesign/customization/src/main/kotlin/dev/aurakai/auraframefx/aura/reactivedesign/customization/ComponentEditor.kt
@@ -134,15 +134,19 @@ class UndoRedoManager {
 }
 
 /**
- * Enhanced Component Editor with full property management
+ * Composable UI for editing a component's transform and appearance properties with undo/redo and preset management.
  *
- * @param componentId Unique identifier for the component being edited
- * @param initialProperties Initial property values (for binding to actual components)
- * @param presets Available property presets
- * @param onPropertyChanged Callback when property value changes
- * @param onPresetSave Callback to save new preset
- * @param onPresetLoad Callback when preset is loaded
- * @param onPresetDelete Callback to delete preset
+ * Provides controls for position (X/Y), size (width/height), rotation, z-index, and opacity; supports saving, loading,
+ * and deleting named presets and tracks changes via an undo/redo command stack.
+ *
+ * @param componentId Identifier of the component being edited.
+ * @param initialProperties Initial values for the editable properties.
+ * @param presets List of saved property presets available for loading.
+ * @param onPropertyChanged Callback invoked when a property value changes; receives the property name and its new value.
+ * @param onPresetSave Callback invoked to persist a newly created preset.
+ * @param onPresetLoad Callback invoked when a preset is loaded.
+ * @param onPresetDelete Callback invoked to request deletion of a preset by its id.
+ * @param modifier Optional [Modifier] to apply to the root layout.
  */
 @Composable
 fun ComponentEditor(


### PR DESCRIPTION
## Summary by Sourcery

Refine ComponentEditor documentation and resolve build errors in CanvasScreen by fixing PathOp invocation and enum iteration

Bug Fixes:
- Fix Pedantic PathOp constructor usage to accept a Path directly and remove unnecessary android.graphics.Path conversion
- Replace items(DrawingTool.values()) with items(DrawingTool.entries) to align with current enum API

Documentation:
- Improve KDoc for ComponentEditor composable with detailed parameter descriptions and UI behavior