### PR TITLE
Fix: Add NDK package.xml corruption fix and prevention

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,37 @@ We use Gradle convention plugins for consistent configuration:
 
 ---
 
+## 🔧 Troubleshooting
+
+### Common Build Issues
+
+#### NDK package.xml Corruption
+If you encounter errors like:
+```
+[CXX5304] Found corrupted package.xml
+org.xml.sax.SAXParseException; 文件提前结束。
+```
+
+**Quick Fix:**
+```bash
+# Windows (PowerShell as Administrator)
+.\fix-ndk-package-xml.ps1
+
+# Linux/Mac
+chmod +x fix-ndk-package-xml.sh
+./fix-ndk-package-xml.sh
+```
+
+See [docs/NDK_PACKAGE_XML_FIX.md](docs/NDK_PACKAGE_XML_FIX.md) for detailed instructions.
+
+#### Other Issues
+- **Gradle sync fails**: Run `./gradlew --refresh-dependencies`
+- **KSP errors**: Ensure you're using JDK 24
+- **Memory issues**: Increase JVM heap in `gradle.properties` (already set to 10GB)
+- **CMake not found**: Install CMake 3.22.1+ via Android Studio SDK Manager
+
+---
+
 ## 🤝 Community
 
 ### Contributing

--- a/docs/NDK_PACKAGE_XML_FIX.md
+++ b/docs/NDK_PACKAGE_XML_FIX.md
@@ -1,0 +1,234 @@
+# NDK package.xml Corruption Fix
+
+## Problem Description
+
+When building the project, you may encounter errors like:
+
+```
+[CXX5304] Found corrupted package.xml at C:\Users\...\Android\Sdk\ndk\25.0.8775105\package.xml
+[CXX5304] Invalid package.xml found at C:\Users\...\Android\Sdk\ndk\25.0.8775105\package.xml and failed to parse using fallback.
+[CXX5304] package.xml parsing problem. 文件提前结束。:
+org.xml.sax.SAXParseException; lineNumber: 1; columnNumber: 1; 文件提前结束。
+```
+
+**Translation:** "文件提前结束。" means "Premature end of file."
+
+## Root Cause
+
+The Android build system scans **all** installed NDK versions in your SDK directory. If any NDK installation has a corrupted (empty or truncated) `package.xml` file, the build fails with a SAXParseException.
+
+This commonly occurs when:
+- NDK installations are interrupted
+- Disk space runs out during installation
+- File system corruption
+- Incomplete downloads or extractions
+
+## Quick Fix
+
+### Windows Users
+
+1. Open PowerShell as Administrator
+2. Navigate to the project root directory
+3. Run the fix script:
+
+```powershell
+.\fix-ndk-package-xml.ps1
+```
+
+### Linux/Mac Users
+
+1. Open Terminal
+2. Navigate to the project root directory
+3. Make the script executable (first time only):
+
+```bash
+chmod +x fix-ndk-package-xml.sh
+```
+
+4. Run the fix script:
+
+```bash
+./fix-ndk-package-xml.sh
+```
+
+## What the Script Does
+
+The fix script:
+
+1. **Detects** your Android SDK location automatically
+2. **Scans** all installed NDK versions
+3. **Identifies** corrupted or missing `package.xml` files
+4. **Creates backups** of existing corrupted files (`.backup` extension)
+5. **Regenerates** valid `package.xml` files with proper structure
+6. **Reports** summary of fixes applied
+
+## Manual Fix (Alternative Method)
+
+If you prefer to fix the issue manually:
+
+### Option 1: Fix Individual package.xml Files
+
+For each corrupted NDK version (e.g., `25.0.8775105`), create a valid `package.xml`:
+
+**Location:** `%LOCALAPPDATA%\Android\Sdk\ndk\25.0.8775105\package.xml` (Windows)
+or `~/Android/Sdk/ndk/25.0.8775105/package.xml` (Linux/Mac)
+
+**Content:**
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:repository xmlns:ns2="http://schemas.android.com/repository/android/common/01" xmlns:ns3="http://schemas.android.com/sdk/android/repo/addon2/01" xmlns:ns4="http://schemas.android.com/repository/android/generic/01" xmlns:ns5="http://schemas.android.com/sdk/android/repo/repository2/01" xmlns:ns6="http://schemas.android.com/sdk/android/repo/sys-img2/01">
+    <localPackage path="ndk;25.0.8775105" obsolete="false">
+        <type-details xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ns4:genericDetailsType"/>
+        <revision>
+            <major>25</major>
+            <minor>0</minor>
+            <micro>8775105</micro>
+        </revision>
+        <display-name>NDK (Side by side) 25.0.8775105</display-name>
+    </localPackage>
+</ns2:repository>
+```
+
+**Important:** Replace version numbers (`25`, `0`, `8775105`) and path (`ndk;25.0.8775105`) to match your specific NDK version.
+
+### Option 2: Delete Unused NDK Versions
+
+If you don't need older NDK versions:
+
+1. Open Android Studio > Tools > SDK Manager > SDK Tools tab
+2. Expand "NDK (Side by side)"
+3. Uncheck versions you don't use (keep 29.0.14206865 for this project)
+4. Click "Apply" to remove unused versions
+
+**Note:** This project uses NDK version **29.0.14206865** as specified in `gradle/libs.versions.toml`.
+
+### Option 3: Specify Exact NDK Path
+
+Add to your `local.properties` file:
+
+```properties
+ndk.dir=C:\\Users\\YourName\\AppData\\Local\\Android\\Sdk\\ndk\\29.0.14206865
+```
+
+This tells Gradle to use a specific NDK version instead of scanning all installed versions.
+
+## Prevention
+
+To prevent this issue in the future:
+
+### 1. Configure Specific NDK Version
+
+The project already specifies NDK version in:
+- `gradle.properties` (line 56): `android.ndkVersion=29.0.14206865`
+- `gradle/libs.versions.toml` (line 185): `ndk = "29.0.14206865"`
+- `app/build.gradle.kts` (line 25): `ndkVersion = libs.versions.ndk.get()`
+
+### 2. Use local.properties Template
+
+Copy `local.properties.template` to `local.properties` and configure your SDK path:
+
+```bash
+# Windows
+copy local.properties.template local.properties
+
+# Linux/Mac
+cp local.properties.template local.properties
+```
+
+Then edit `local.properties` to specify your SDK location.
+
+### 3. Keep NDKs Up to Date
+
+Use Android Studio SDK Manager to:
+- Keep installed NDKs updated
+- Remove unused NDK versions
+- Reinstall corrupted NDKs
+
+## Technical Details
+
+### Error Breakdown
+
+```
+org.xml.sax.SAXParseException; lineNumber: 1; columnNumber: 1; 文件提前结束。
+```
+
+- **SAXParseException:** XML parser error
+- **lineNumber: 1; columnNumber: 1:** Error at the very start of the file
+- **文件提前结束 (Premature end of file):** File is empty or truncated
+
+### Why This Happens
+
+The Android Gradle Plugin (AGP) 9.0+ uses:
+- `com.android.repository.impl.manager.LocalRepoLoaderImpl` to scan SDK packages
+- `com.android.build.gradle.internal.cxx.configure.CmakeLocator` to find CMake installations
+- These components parse `package.xml` for **all** NDK versions during configuration
+
+Even if your project specifies a specific NDK version, the build system still **scans all NDKs** to build an inventory. If any `package.xml` is corrupted, the build fails.
+
+### What package.xml Contains
+
+The `package.xml` file describes:
+- Package path (e.g., `ndk;25.0.8775105`)
+- Version information (major, minor, micro)
+- Display name
+- Package type and metadata
+
+This metadata is used by Android Studio SDK Manager and Gradle build system.
+
+## Verification
+
+After running the fix script, verify the fix worked:
+
+1. **Check the script output** for "Successfully fixed" count
+2. **Run a Gradle sync:**
+   ```bash
+   ./gradlew --refresh-dependencies
+   ```
+3. **Build the project:**
+   ```bash
+   ./gradlew build
+   ```
+
+If you still see errors, run the script again or manually inspect the `package.xml` files.
+
+## Related Files
+
+- `fix-ndk-package-xml.ps1` - PowerShell fix script (Windows)
+- `fix-ndk-package-xml.sh` - Bash fix script (Linux/Mac)
+- `local.properties.template` - Template for local SDK configuration
+- `gradle.properties` - Project-wide Gradle settings (includes NDK version)
+- `gradle/libs.versions.toml` - Version catalog (defines NDK 29.0.14206865)
+
+## FAQ
+
+**Q: Why do I have multiple NDK versions installed?**
+A: Android Studio installs NDK versions as needed for different projects. Each NDK version can coexist side-by-side.
+
+**Q: Can I delete all NDKs except the one I need?**
+A: Yes, but ensure you keep the version required by your project (29.0.14206865). Other projects may need different versions.
+
+**Q: Will this affect other Android projects?**
+A: No, the fix only regenerates metadata files. It doesn't modify NDK binaries or affect other projects.
+
+**Q: Do I need to run the script every time I build?**
+A: No, you only need to run it once to fix corrupted files. The fix is permanent unless the files get corrupted again.
+
+**Q: What if the script doesn't work?**
+A: Try these alternatives:
+1. Reinstall the corrupted NDK version via Android Studio SDK Manager
+2. Delete the corrupted NDK directory entirely
+3. Use `ndk.dir` in `local.properties` to specify exact NDK path
+
+## Support
+
+If you continue experiencing issues:
+
+1. Check that you have NDK 29.0.14206865 installed
+2. Verify your Android SDK path in `local.properties`
+3. Ensure you have write permissions to the SDK directory
+4. Review the error logs for other potential issues
+
+For project-specific issues, open a GitHub issue with:
+- Full error message
+- Output from the fix script
+- Your NDK versions (run `ls $ANDROID_SDK_ROOT/ndk` or `dir %ANDROID_SDK_ROOT%\ndk`)

--- a/fix-ndk-package-xml.ps1
+++ b/fix-ndk-package-xml.ps1
@@ -1,0 +1,145 @@
+# ============================================================================
+# Fix Corrupted NDK package.xml Files
+# ============================================================================
+# This script fixes corrupted (empty or truncated) package.xml files in
+# Android NDK installations by regenerating them with proper content.
+#
+# Problem: SAXParseException "Premature end of file" (文件提前结束。)
+# Cause: Empty or corrupted package.xml files in NDK directories
+# Solution: Regenerate package.xml with valid content
+#
+# Usage: Run this script from PowerShell with Administrator privileges
+# ============================================================================
+
+Write-Host "=====================================================================" -ForegroundColor Cyan
+Write-Host "NDK package.xml Fix Script" -ForegroundColor Cyan
+Write-Host "=====================================================================" -ForegroundColor Cyan
+Write-Host ""
+
+# Detect Android SDK location
+$AndroidSdkRoot = $env:ANDROID_SDK_ROOT
+if (-not $AndroidSdkRoot) {
+    $AndroidSdkRoot = $env:ANDROID_HOME
+}
+if (-not $AndroidSdkRoot) {
+    # Try default Windows location
+    $AndroidSdkRoot = "$env:LOCALAPPDATA\Android\Sdk"
+}
+
+if (-not (Test-Path $AndroidSdkRoot)) {
+    Write-Host "ERROR: Cannot find Android SDK directory!" -ForegroundColor Red
+    Write-Host "Please set ANDROID_SDK_ROOT or ANDROID_HOME environment variable" -ForegroundColor Yellow
+    Write-Host "or ensure SDK is installed at: $AndroidSdkRoot" -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "Android SDK Location: $AndroidSdkRoot" -ForegroundColor Green
+Write-Host ""
+
+$NdkDir = Join-Path $AndroidSdkRoot "ndk"
+
+if (-not (Test-Path $NdkDir)) {
+    Write-Host "ERROR: NDK directory not found at: $NdkDir" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Scanning NDK installations..." -ForegroundColor Cyan
+Write-Host ""
+
+# Get all NDK version directories
+$NdkVersions = Get-ChildItem -Path $NdkDir -Directory
+
+$FixedCount = 0
+$CorruptedCount = 0
+
+foreach ($NdkVersion in $NdkVersions) {
+    $PackageXmlPath = Join-Path $NdkVersion.FullName "package.xml"
+
+    Write-Host "Checking: $($NdkVersion.Name)" -ForegroundColor White
+
+    if (-not (Test-Path $PackageXmlPath)) {
+        Write-Host "  [MISSING] package.xml not found, creating..." -ForegroundColor Yellow
+        $CorruptedCount++
+    }
+    else {
+        $FileSize = (Get-Item $PackageXmlPath).Length
+        if ($FileSize -eq 0) {
+            Write-Host "  [CORRUPTED] package.xml is empty (0 bytes)" -ForegroundColor Red
+            $CorruptedCount++
+        }
+        else {
+            # Try to parse the XML to check if it's valid
+            try {
+                [xml]$TestXml = Get-Content $PackageXmlPath -Raw -ErrorAction Stop
+                Write-Host "  [OK] package.xml is valid" -ForegroundColor Green
+                continue
+            }
+            catch {
+                Write-Host "  [CORRUPTED] package.xml is invalid: $($_.Exception.Message)" -ForegroundColor Red
+                $CorruptedCount++
+            }
+        }
+    }
+
+    # Generate new package.xml
+    Write-Host "  [FIXING] Generating new package.xml..." -ForegroundColor Yellow
+
+    # Extract version number from directory name (e.g., "25.0.8775105" -> version parts)
+    $VersionString = $NdkVersion.Name
+    $VersionParts = $VersionString -split '\.'
+
+    # Create backup if file exists
+    if (Test-Path $PackageXmlPath) {
+        $BackupPath = "$PackageXmlPath.backup"
+        Copy-Item $PackageXmlPath $BackupPath -Force
+        Write-Host "  [BACKUP] Created backup: package.xml.backup" -ForegroundColor Cyan
+    }
+
+    # Generate XML content
+    $XmlContent = @"
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:repository xmlns:ns2="http://schemas.android.com/repository/android/common/01" xmlns:ns3="http://schemas.android.com/sdk/android/repo/addon2/01" xmlns:ns4="http://schemas.android.com/repository/android/generic/01" xmlns:ns5="http://schemas.android.com/sdk/android/repo/repository2/01" xmlns:ns6="http://schemas.android.com/sdk/android/repo/sys-img2/01">
+    <localPackage path="ndk;$VersionString" obsolete="false">
+        <type-details xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ns4:genericDetailsType"/>
+        <revision>
+            <major>$($VersionParts[0])</major>
+            <minor>$($VersionParts[1])</minor>
+            <micro>$($VersionParts[2])</micro>
+        </revision>
+        <display-name>NDK (Side by side) $VersionString</display-name>
+    </localPackage>
+</ns2:repository>
+"@
+
+    # Write the new package.xml
+    try {
+        $XmlContent | Out-File -FilePath $PackageXmlPath -Encoding UTF8 -Force
+        Write-Host "  [SUCCESS] Created new package.xml" -ForegroundColor Green
+        $FixedCount++
+    }
+    catch {
+        Write-Host "  [ERROR] Failed to write package.xml: $($_.Exception.Message)" -ForegroundColor Red
+    }
+
+    Write-Host ""
+}
+
+Write-Host "=====================================================================" -ForegroundColor Cyan
+Write-Host "Summary:" -ForegroundColor Cyan
+Write-Host "  Total NDK versions scanned: $($NdkVersions.Count)" -ForegroundColor White
+Write-Host "  Corrupted/Missing package.xml: $CorruptedCount" -ForegroundColor Yellow
+Write-Host "  Successfully fixed: $FixedCount" -ForegroundColor Green
+Write-Host "=====================================================================" -ForegroundColor Cyan
+Write-Host ""
+
+if ($FixedCount -gt 0) {
+    Write-Host "Done! Your NDK package.xml files have been fixed." -ForegroundColor Green
+    Write-Host "You can now run your build again." -ForegroundColor Green
+}
+else {
+    Write-Host "No corrupted package.xml files found." -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "Press any key to exit..."
+$null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")

--- a/fix-ndk-package-xml.sh
+++ b/fix-ndk-package-xml.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# ============================================================================
+# Fix Corrupted NDK package.xml Files
+# ============================================================================
+# This script fixes corrupted (empty or truncated) package.xml files in
+# Android NDK installations by regenerating them with proper content.
+#
+# Problem: SAXParseException "Premature end of file" (文件提前结束。)
+# Cause: Empty or corrupted package.xml files in NDK directories
+# Solution: Regenerate package.xml with valid content
+#
+# Usage: chmod +x fix-ndk-package-xml.sh && ./fix-ndk-package-xml.sh
+# ============================================================================
+
+echo "====================================================================="
+echo "NDK package.xml Fix Script"
+echo "====================================================================="
+echo ""
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+WHITE='\033[1;37m'
+NC='\033[0m' # No Color
+
+# Detect Android SDK location
+if [ -n "$ANDROID_SDK_ROOT" ]; then
+    ANDROID_SDK="$ANDROID_SDK_ROOT"
+elif [ -n "$ANDROID_HOME" ]; then
+    ANDROID_SDK="$ANDROID_HOME"
+elif [ -d "$HOME/Android/Sdk" ]; then
+    ANDROID_SDK="$HOME/Android/Sdk"
+elif [ -d "$HOME/Library/Android/sdk" ]; then
+    # macOS default location
+    ANDROID_SDK="$HOME/Library/Android/sdk"
+else
+    echo -e "${RED}ERROR: Cannot find Android SDK directory!${NC}"
+    echo -e "${YELLOW}Please set ANDROID_SDK_ROOT or ANDROID_HOME environment variable${NC}"
+    exit 1
+fi
+
+if [ ! -d "$ANDROID_SDK" ]; then
+    echo -e "${RED}ERROR: Android SDK directory not found at: $ANDROID_SDK${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}Android SDK Location: $ANDROID_SDK${NC}"
+echo ""
+
+NDK_DIR="$ANDROID_SDK/ndk"
+
+if [ ! -d "$NDK_DIR" ]; then
+    echo -e "${RED}ERROR: NDK directory not found at: $NDK_DIR${NC}"
+    exit 1
+fi
+
+echo -e "${CYAN}Scanning NDK installations...${NC}"
+echo ""
+
+FIXED_COUNT=0
+CORRUPTED_COUNT=0
+TOTAL_COUNT=0
+
+# Iterate through all NDK version directories
+for NDK_VERSION_DIR in "$NDK_DIR"/*; do
+    if [ ! -d "$NDK_VERSION_DIR" ]; then
+        continue
+    fi
+
+    TOTAL_COUNT=$((TOTAL_COUNT + 1))
+    NDK_VERSION=$(basename "$NDK_VERSION_DIR")
+    PACKAGE_XML="$NDK_VERSION_DIR/package.xml"
+
+    echo -e "${WHITE}Checking: $NDK_VERSION${NC}"
+
+    IS_CORRUPTED=false
+
+    if [ ! -f "$PACKAGE_XML" ]; then
+        echo -e "  ${YELLOW}[MISSING] package.xml not found, creating...${NC}"
+        IS_CORRUPTED=true
+        CORRUPTED_COUNT=$((CORRUPTED_COUNT + 1))
+    else
+        FILE_SIZE=$(stat -f%z "$PACKAGE_XML" 2>/dev/null || stat -c%s "$PACKAGE_XML" 2>/dev/null)
+        if [ "$FILE_SIZE" -eq 0 ]; then
+            echo -e "  ${RED}[CORRUPTED] package.xml is empty (0 bytes)${NC}"
+            IS_CORRUPTED=true
+            CORRUPTED_COUNT=$((CORRUPTED_COUNT + 1))
+        else
+            # Try to parse the XML to check if it's valid
+            if ! xmllint --noout "$PACKAGE_XML" 2>/dev/null; then
+                echo -e "  ${RED}[CORRUPTED] package.xml is invalid${NC}"
+                IS_CORRUPTED=true
+                CORRUPTED_COUNT=$((CORRUPTED_COUNT + 1))
+            else
+                echo -e "  ${GREEN}[OK] package.xml is valid${NC}"
+                echo ""
+                continue
+            fi
+        fi
+    fi
+
+    if [ "$IS_CORRUPTED" = true ]; then
+        echo -e "  ${YELLOW}[FIXING] Generating new package.xml...${NC}"
+
+        # Extract version parts from directory name (e.g., "25.0.8775105")
+        IFS='.' read -r MAJOR MINOR MICRO <<< "$NDK_VERSION"
+
+        # Create backup if file exists
+        if [ -f "$PACKAGE_XML" ]; then
+            cp "$PACKAGE_XML" "$PACKAGE_XML.backup"
+            echo -e "  ${CYAN}[BACKUP] Created backup: package.xml.backup${NC}"
+        fi
+
+        # Generate XML content
+        cat > "$PACKAGE_XML" << EOF
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:repository xmlns:ns2="http://schemas.android.com/repository/android/common/01" xmlns:ns3="http://schemas.android.com/sdk/android/repo/addon2/01" xmlns:ns4="http://schemas.android.com/repository/android/generic/01" xmlns:ns5="http://schemas.android.com/sdk/android/repo/repository2/01" xmlns:ns6="http://schemas.android.com/sdk/android/repo/sys-img2/01">
+    <localPackage path="ndk;$NDK_VERSION" obsolete="false">
+        <type-details xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="ns4:genericDetailsType"/>
+        <revision>
+            <major>$MAJOR</major>
+            <minor>$MINOR</minor>
+            <micro>$MICRO</micro>
+        </revision>
+        <display-name>NDK (Side by side) $NDK_VERSION</display-name>
+    </localPackage>
+</ns2:repository>
+EOF
+
+        if [ $? -eq 0 ]; then
+            echo -e "  ${GREEN}[SUCCESS] Created new package.xml${NC}"
+            FIXED_COUNT=$((FIXED_COUNT + 1))
+        else
+            echo -e "  ${RED}[ERROR] Failed to write package.xml${NC}"
+        fi
+    fi
+
+    echo ""
+done
+
+echo "====================================================================="
+echo -e "${CYAN}Summary:${NC}"
+echo -e "  ${WHITE}Total NDK versions scanned: $TOTAL_COUNT${NC}"
+echo -e "  ${YELLOW}Corrupted/Missing package.xml: $CORRUPTED_COUNT${NC}"
+echo -e "  ${GREEN}Successfully fixed: $FIXED_COUNT${NC}"
+echo "====================================================================="
+echo ""
+
+if [ $FIXED_COUNT -gt 0 ]; then
+    echo -e "${GREEN}Done! Your NDK package.xml files have been fixed.${NC}"
+    echo -e "${GREEN}You can now run your build again.${NC}"
+else
+    echo -e "${GREEN}No corrupted package.xml files found.${NC}"
+fi
+
+echo ""

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,3 +46,11 @@ org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 org.gradle.jvmargs=-Xmx10g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC
 # Kotlin bytecode target guard
 kotlin.jvm.target.validation.mode=warning
+
+# ===== NDK Configuration =====
+# Prevent scanning all installed NDKs (reduces build time and avoids corrupted package.xml issues)
+# The project uses NDK 29.0.14206865 as specified in gradle/libs.versions.toml
+# If you encounter "CXX5304: Found corrupted package.xml" errors, run:
+#   Windows: .\fix-ndk-package-xml.ps1
+#   Linux/Mac: ./fix-ndk-package-xml.sh
+android.ndkVersion=29.0.14206865

--- a/local.properties.template
+++ b/local.properties.template
@@ -1,0 +1,49 @@
+# ============================================================================
+# local.properties Template
+# ============================================================================
+# Copy this file to 'local.properties' (without the .template extension)
+# and configure your local Android SDK paths.
+#
+# IMPORTANT: local.properties should NEVER be committed to version control
+# as it contains machine-specific paths.
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# Android SDK Location (REQUIRED)
+# ----------------------------------------------------------------------------
+# Path to your Android SDK installation
+# Windows example: sdk.dir=C\:\\Users\\YourName\\AppData\\Local\\Android\\Sdk
+# Linux example: sdk.dir=/home/username/Android/Sdk
+# macOS example: sdk.dir=/Users/username/Library/Android/sdk
+
+sdk.dir=
+
+# ----------------------------------------------------------------------------
+# NDK Configuration (Optional)
+# ----------------------------------------------------------------------------
+# Specify the exact NDK version to use (recommended to avoid scanning all NDKs)
+# This project uses NDK 29.0.14206865
+# If you have multiple NDKs installed and encounter "CXX5304: Found corrupted
+# package.xml" errors, run the fix script:
+#   Windows: .\fix-ndk-package-xml.ps1
+#   Linux/Mac: ./fix-ndk-package-xml.sh
+
+# Uncomment and specify exact NDK path to avoid scanning all NDK versions:
+# ndk.dir=C\:\\Users\\YourName\\AppData\\Local\\Android\\Sdk\\ndk\\29.0.14206865
+
+# ----------------------------------------------------------------------------
+# Gemini API Key (REQUIRED for AI features)
+# ----------------------------------------------------------------------------
+# Get your API key from: https://aistudio.google.com/app/apikey
+# This is required for the Genesis Protocol (Gemini 2.0 Flash integration)
+
+GEMINI_API_KEY=
+
+# ----------------------------------------------------------------------------
+# Additional Configuration (Optional)
+# ----------------------------------------------------------------------------
+# CMake version (if using a specific version)
+# cmake.dir=
+
+# Java/JDK home (usually auto-detected, but can be set manually)
+# org.gradle.java.home=


### PR DESCRIPTION
This commit addresses the CXX5304 "Found corrupted package.xml" error that occurs when the Android build system encounters empty or truncated package.xml files in NDK installations.

Changes:
- Add fix-ndk-package-xml.ps1 (Windows PowerShell script)
- Add fix-ndk-package-xml.sh (Linux/Mac bash script)
- Add docs/NDK_PACKAGE_XML_FIX.md (comprehensive documentation)
- Add local.properties.template (SDK configuration guide)
- Update gradle.properties: Add android.ndkVersion property to prevent scanning all NDKs
- Update README.md: Add troubleshooting section with quick fix

The scripts automatically:
1. Detect Android SDK location
2. Scan all installed NDK versions
3. Identify corrupted/missing package.xml files
4. Create backups of corrupted files
5. Regenerate valid package.xml with proper structure

This fix resolves SAXParseException errors:
"org.xml.sax.SAXParseException; 文件提前结束。"
(Premature end of file)

Affected NDK versions in the reported error:
- 25.0.8775105, 25.2.9519653
- 26.0.10404224, 26.3.11579264
- 27.1.12297006

Project uses NDK 29.0.14206865 (configured in libs.versions.toml)

## Summary by Sourcery

Automate detection and repair of corrupted Android NDK package.xml files to resolve SAXParseException build errors and prevent future issues by specifying a dedicated NDK version and providing comprehensive documentation and scripts

New Features:
- Add cross-platform scripts (PowerShell and Bash) to detect and repair corrupted Android NDK package.xml files automatically

Enhancements:
- Configure android.ndkVersion in gradle.properties to target a specific NDK and avoid scanning all installations

Documentation:
- Add detailed NDK_PACKAGE_XML_FIX.md documentation and update README with a troubleshooting section and local.properties.template guidance