### PR TITLE
Claude/fix corrupted ndk package xml 01 hh9ou y ho c xtt wk88 x sb ys r

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -47,12 +47,9 @@ jobs:
       run: echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "ndk;29.0.14206865" || true
 
     - name: Gradle Build (assemble only, skip tests)
-      run: ./gradlew assembleDebug --no-daemon --stacktrace --warning-mode all
+      run: ./gradlew assembleDebug --no-daemon --stacktrace --warning-mode all -Dorg.gradle.java.installations.auto-download=false
       continue-on-error: true
       id: build_step
-      env:
-        JAVA_HOME: ${{ env.JAVA_HOME }}
-        org.gradle.java.installations.auto-download: false
 
     - name: Display Build Summary
       if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,10 @@ jobs:
           gradle-home-cache-cleanup: true
 
       - name: Check build-logic
-        run: ./gradlew :build-logic:build --no-daemon
+        run: ./gradlew :build-logic:build --no-daemon -Dorg.gradle.java.installations.auto-download=false
 
       - name: Assemble Debug APK
-        run: ./gradlew assembleDebug --no-daemon --stacktrace
-        env:
-          org.gradle.java.installations.auto-download: false
+        run: ./gradlew assembleDebug --no-daemon --stacktrace -Dorg.gradle.java.installations.auto-download=false
 
       - name: Upload Debug APK
         uses: actions/upload-artifact@v5
@@ -102,18 +100,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Set up JDK 21
+      - name: Set up JDK 24 (Oracle EA)
         uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
-          java-version: '21'
+          distribution: 'oracle'
+          java-version: '24-ea'
           cache: 'gradle'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
       - name: Check for dependency updates
-        run: ./gradlew dependencyUpdates -Drevision=release --no-daemon || true
+        run: ./gradlew dependencyUpdates -Drevision=release --no-daemon -Dorg.gradle.java.installations.auto-download=false || true
 
       - name: Upload dependency reports
         if: always()
@@ -134,11 +132,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Set up JDK 21
+      - name: Set up JDK 24 (Oracle EA)
         uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
-          java-version: '21'
+          distribution: 'oracle'
+          java-version: '24-ea'
           cache: 'gradle'
 
       - name: Set up Android SDK with NDK
@@ -152,7 +150,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build Release APK
-        run: ./gradlew assembleRelease --no-daemon --stacktrace
+        run: ./gradlew assembleRelease --no-daemon --stacktrace -Dorg.gradle.java.installations.auto-download=false
 
       - name: Sign APK
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -73,11 +73,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Set up JDK 21
+      - name: Set up JDK 24 (Oracle EA)
         uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
-          java-version: '21'
+          distribution: 'oracle'
+          java-version: '24-ea'
           cache: 'gradle'
 
       - name: Set up Android SDK with NDK
@@ -91,7 +91,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build Release APK
-        run: ./gradlew assembleRelease --no-daemon
+        run: ./gradlew assembleRelease --no-daemon -Dorg.gradle.java.installations.auto-download=false
 
       - name: Get APK size
         id: apk-size

--- a/app/ai_backend/list/build.gradle.kts
+++ b/app/ai_backend/list/build.gradle.kts
@@ -8,10 +8,6 @@
 group = "dev.aurakai.auraframefx.list"
 version = "1.0.0"
 
-java {
-    toolchain { languageVersion = JavaLanguageVersion.of(25) }
-}
-
 kotlin {
     jvmToolchain(24) // Kotlin targets JVM 24 bytecode (max supported by Kotlin 2.3.0-Beta2)
 }

--- a/aura/reactivedesign/chromacore/src/main/build-logic/build.gradle.kts
+++ b/aura/reactivedesign/chromacore/src/main/build-logic/build.gradle.kts
@@ -80,12 +80,6 @@ kotlin {
     jvmToolchain(24)
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(24))
-    }
-}
-
 tasks.processResources {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -28,12 +28,6 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEa
     }
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(24))
-    }
-}
-
 gradlePlugin {
     plugins {
         register("genesisApplication") {


### PR DESCRIPTION
## Summary by Sourcery

Update CI workflows to use Oracle JDK 24-ea, disable Gradle's auto-download of Java installations, and remove redundant Java toolchain configurations from build scripts

Enhancements:
- Remove redundant java.toolchain blocks from Kotlin Gradle scripts

CI:
- Switch setup-java actions to Oracle JDK 24-ea in CI, PR checks, and build-check workflows
- Add -Dorg.gradle.java.installations.auto-download=false flag to all Gradle invocations in CI workflows