### PR TITLE
Fix: Correct YukiHookAPI KSP catalog accessor naming

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -150,7 +150,7 @@ dependencies {
 
     // YukiHook API
     compileOnly(libs.yukihookapi.api)
-    ksp(libs.yukihookapi.ksp)
+    ksp(libs.yukihookapi.ksp.xposed)
 
     // Firebase BOM (Bill of Materials) for version management
     implementation(platform(libs.firebase.bom))

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -32,5 +32,5 @@ dependencies {
     compileOnly(files("$projectDir/libs/api-82.jar"))
 
     // YukiHook API Code Generation (Xposed framework)
-    ksp(libs.yukihookapi.ksp)
+    ksp(libs.yukihookapi.ksp.xposed)
 }

--- a/feature-module/build.gradle.kts
+++ b/feature-module/build.gradle.kts
@@ -35,5 +35,5 @@ dependencies {
     compileOnly(files("$projectDir/libs/api-82.jar"))
 
     // YukiHook API Code Generation (Xposed framework)
-    ksp(libs.yukihookapi.ksp)
+    ksp(libs.yukihookapi.ksp.xposed)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -343,7 +343,7 @@ mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 # Xposed API (original, provided by LSPosed)
 xposed-api = { group = "de.robv.android.xposed", name = "api", version.ref = "xposed" }
 yukihookapi-api = { group = "com.highcapable.yukihookapi", name = "api", version.ref = "yukihookapi" }
-yukihookapi-ksp = { group = "com.highcapable.yukihookapi", name = "ksp-xposed", version.ref = "yukihookapi" }
+yukihookapi-ksp-xposed = { group = "com.highcapable.yukihookapi", name = "ksp-xposed", version.ref = "yukihookapi" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 
 # ============================================================================


### PR DESCRIPTION
**Problem:**
- Version catalog key was `yukihookapi-ksp` creating accessor `libs.yukihookapi.ksp`
- Test expected `libs.yukihookapi.ksp.xposed` for clarity
- Accessor didn't make it explicit we're using the "ksp-xposed" artifact

**Root Cause:**
The catalog key naming convention should match the artifact name suffix to create explicit, self-documenting accessors.

**Solution:**
1. Renamed catalog key: `yukihookapi-ksp` → `yukihookapi-ksp-xposed`
2. Updated all module references:
   - app/build.gradle.kts:153
   - core/ui/build.gradle.kts:35
   - feature-module/build.gradle.kts:38
3. Now uses explicit accessor: `libs.yukihookapi.ksp.xposed`

**Files Changed:**
- gradle/libs.versions.toml (line 346)
- app/build.gradle.kts
- core/ui/build.gradle.kts
- feature-module/build.gradle.kts

**Verification:**
✓ Catalog key: `yukihookapi-ksp-xposed`
✓ Artifact name: "ksp-xposed" (unchanged - correct) ✓ All modules use: `libs.yukihookapi.ksp.xposed`
✓ Matches test expectations in AppBuildGradleChangesTest:64

This follows the Genesis convention pattern where catalog keys explicitly indicate the artifact variant being used.

## Summary by Sourcery

Align the YukiHookAPI KSP catalog key with its `ksp-xposed` artifact suffix and update all module dependencies to use the new accessor

Bug Fixes:
- Update KSP dependency declarations in app, core/ui, and feature-module to use libs.yukihookapi.ksp.xposed

Build:
- Rename version catalog key from yukihookapi-ksp to yukihookapi-ksp-xposed in libs.versions.toml